### PR TITLE
feat(012): record distance history for GETDIST temporal nodes

### DIFF
--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -975,12 +975,15 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
     }
 #endif
 
-    // Capture temporal history before GP evaluation (for GETDPHI_PREV, GETDTHETA_PREV, etc.)
+    // Capture temporal history before GP evaluation (for GETDPHI_PREV, GETDTHETA_PREV, GETDIST_PREV, etc.)
     {
       VectorPathProvider pathProvider(path, aircraftState.getThisPathIndex());
       gp_scalar dPhi = executeGetDPhi(pathProvider, aircraftState, 0.0f);
       gp_scalar dTheta = executeGetDTheta(pathProvider, aircraftState, 0.0f);
-      aircraftState.recordErrorHistory(dPhi, dTheta, simTimeMsec);
+      gp_vec3 targetPos = getInterpolatedTargetPosition(
+          pathProvider, static_cast<int32_t>(aircraftState.getSimTimeMsec()), 0.0f);
+      gp_scalar distance = (targetPos - aircraftState.getPosition()).norm();
+      aircraftState.recordErrorHistory(dPhi, dTheta, distance, simTimeMsec);
     }
 
     // Evaluate immediately on this snapshot


### PR DESCRIPTION
## Summary

- Update `recordErrorHistory()` call to include distance measurement, matching the updated `AircraftState` API from GP repo 012 branch
- Enables `GETDIST_PREV(n)` and `GETDIST_RATE` nodes to work in CRRCSim live visualization mode

## Test plan

- [ ] `cd ~/crsim/crrcsim-0.9.13/build && make` compiles successfully
- [ ] Live CRRCSim visualization with GP controller using GETDIST nodes produces valid behavior

**Companion PR**: https://github.com/gcmcnutt/GP/pull/18

🤖 Generated with [Claude Code](https://claude.com/claude-code)