### PR TITLE
feat(023): autoc bridge — engage delay, direction cosines, hb1 FDM tuning

### DIFF
--- a/models/hb1_streamer.xml
+++ b/models/hb1_streamer.xml
@@ -25,7 +25,9 @@ Extra drag and slightly softer pitch authority to match the mushy feel seen in r
   <aero version="1" units="1">
     <!-- Reference speed lowered to match ~10-11 m/s cruise with streamer -->
     <ref chord="0.178" span="0.762" area="0.136" speed="11.0" />
-    <misc Alpha_0="0" eta_loc="0.25" CG_arm="0.25" span_eff="0.82" />
+    <!-- 023: CG_arm 0.25→0.28, real craft is more neutral pitch trim.
+         At 0.25 the sim nose-dives on throttle cut instead of mushing level. -->
+    <misc Alpha_0="0" eta_loc="0.25" CG_arm="0.28" span_eff="0.82" />
     <!-- Pitch tuning history:
          Original: Cm_de=-0.22, Cm_q=-3.6
          018 attempt 1: Cm_de=-0.144, Cm_q=-5.5 → way too sluggish (39°/s)
@@ -39,6 +41,11 @@ Extra drag and slightly softer pitch authority to match the mushy feel seen in r
          For variations: Cm_q range -3.6 (no streamer) to -5.0 (25ft streamer). -->
     <!-- 021 flight 2026-04-03: sim 71°/s vs flight 200°/s at full stick (0.36x).
          Cm_de -0.24→-0.36 (1.5x, expecting ~2.5-3x rate increase from nonlinear amplification) -->
+    <!-- 023 flight-data comparison: Cm_0 adjustments FAILED.
+         -0.10: nose-dives on launch. -0.04: NN pegs full pitch-up (98% sat).
+         The pitch trim gap is NOT a simple Cm_0 offset — likely involves
+         alpha regime, launch dynamics, or CG_arm interaction.
+         Reverted to original +0.015.  Keep drag/thrust changes only. -->
     <m Cm_0="0.015" Cm_a="-0.55" Cm_q="-4.2" Cm_de="-0.36" />
     <!-- Lift/stall tuning (019 step 2):
          CL_max=1.2 + CL_drop=0.1 + CD_stall=0 meant the wing barely stalls.
@@ -58,8 +65,10 @@ Extra drag and slightly softer pitch authority to match the mushy feel seen in r
          CL_max 0.9→1.2: foam flying wing, no prop wash on elevons.
            At 12 m/s: 87 deg/s (was 53). At 17 m/s: 156 deg/s (flight ~200).
          CL_min -0.5→-1.0: restore inverted authority for all-attitude flight. -->
+    <!-- 023: CL_drop 0.5→0.15 (mushy stall, no snap roll — matches real foam wing).
+         CD_stall stays 0.10 (drag penalty still there, just no sharp lift break). -->
     <lift CL_0="0.18" CL_max="1.2" CL_min="-1.0" CL_a="4.7" CL_q="5.5"
-       CL_de="0.55" CL_drop="0.5" CL_CD0="0.35" />
+       CL_de="0.55" CL_drop="0.15" CL_CD0="0.35" />
     <!-- Drag tuning history:
          Original: CD_prof=0.065 → sim Vmax≈32m/s (2× real 17m/s)
          018: CD_prof=0.18 → sim Vmax≈18m/s (good!) but drag curve too steep —
@@ -75,7 +84,9 @@ Extra drag and slightly softer pitch authority to match the mushy feel seen in r
          Left turns at 20-35° nearly matched flight (66% vs 65%, 15.5 vs 15.0 m/s).
          0.14→0.18: targeting idle glide ~12m/s to close the gap.
          F=6.5 stays — thrust OK (full power sim 15 vs flight 17, close enough). -->
-    <drag CD_prof="0.18" Uexp_CD="-0.5" CD_stall="0.10" CD_CLsq="0.04" CD_AIsq="0.05"
+    <!-- 023 flight-data comparison: sim cruise at 81% throttle, real at 60%.
+         CD_prof 0.18→0.15 (17% less drag) + thrust F 6.5→7.5 (15% more) to close gap. -->
+    <drag CD_prof="0.15" Uexp_CD="-0.5" CD_stall="0.10" CD_CLsq="0.04" CD_AIsq="0.05"
        CD_ELsq="0.05" />
     <Y CY_b="-0.12" CY_p="-0.05" CY_r="0.08" CY_dr="0" CY_da="0.03" />
     <!-- Roll: 020 pass 2. BIG1(0.10/-0.55)=0.41× flt, BIG2(0.14/-0.39)=2.15× flt. Split: target ~1× -->
@@ -85,8 +96,15 @@ Extra drag and slightly softer pitch authority to match the mushy feel seen in r
     <!-- 021 analysis: linearized model p_ss = Cl_da*V/(|Cl_p|*b) = 346 deg/s at
          0.18. Flight target 500 deg/s → need 1.44x. Cl_da 0.18→0.26.
          Linearized prediction: 0.26*12/(0.47*0.762) = 499 deg/s. -->
-    <l Cl_b="-0.06" Cl_p="-0.47" Cl_r="0.05" Cl_dr="0" Cl_da="0.26" />
-    <n Cn_b="0.03" Cn_p="-0.005" Cn_r="-0.015" Cn_dr="0"
+    <!-- 023 flight-data comparison: sim peak 900°/s vs real MANUAL 615°/s.
+         Cl_da 0.26→0.18 (~30% reduction, targeting ~630°/s peak). -->
+    <!-- 023: Cl_da 0.18 felt sluggish at cruise. 0.22 splits between 0.18 (sluggish)
+         and 0.26 (too hot). Linearized: 0.22*13/(0.47*0.762) = 520°/s (real ~615). -->
+    <l Cl_b="-0.06" Cl_p="-0.47" Cl_r="0.05" Cl_dr="0" Cl_da="0.22" />
+    <!-- 023: Cn_b 0.03→0.07, Cn_r -0.015→-0.04.  Real HB1 has vertical fin
+         behind motor — significantly more yaw stability than a pure flying wing.
+         Comparable to sailplanes with fin (F3F=0.038, Pilatus=0.044). -->
+    <n Cn_b="0.07" Cn_p="-0.005" Cn_r="-0.04" Cn_dr="0"
        Cn_da="-0.010" />
   </aero>
   <config version="1">
@@ -106,7 +124,8 @@ Extra drag and slightly softer pitch authority to match the mushy feel seen in r
       <!-- 019 throttle tuning pass 4: F=6.5, CD_prof=0.14.
            Steady flight analysis: flight cruises 14m/s at 20-40% power.
            Idle glide should be ~10m/s not 16m/s — need more drag. -->
-      <automagic F="6.5" V="11.1">
+      <!-- 023: F 6.5→7.5 to match real cruise throttle (~60% vs sim 81%) -->
+      <automagic F="7.5" V="11.1">
         <battery throttle_min="0">
           <automagic T="420" />
           <shaft J="0" brake="0">

--- a/models/hb1_streamer.xml
+++ b/models/hb1_streamer.xml
@@ -100,11 +100,30 @@ Extra drag and slightly softer pitch authority to match the mushy feel seen in r
          Cl_da 0.26→0.18 (~30% reduction, targeting ~630°/s peak). -->
     <!-- 023: Cl_da 0.18 felt sluggish at cruise. 0.22 splits between 0.18 (sluggish)
          and 0.26 (too hot). Linearized: 0.22*13/(0.47*0.762) = 520°/s (real ~615). -->
-    <l Cl_b="-0.06" Cl_p="-0.47" Cl_r="0.05" Cl_dr="0" Cl_da="0.22" />
+    <!-- 023 adjust4: Cl_b tuning history:
+         -0.06 (original): sideslip self-corrects well but maybe too much?
+         -0.01: sideslip unchecked → yaw/roll 0.314 (4x too high)
+         -0.03: still 0.344 — not enough correction
+         -0.05: close to original.  Motor mount height + vertical fin give
+         real effective dihedral despite flat wing planform.  The fin behind
+         the motor acts like a low dihedral equivalent. -->
+    <l Cl_b="-0.05" Cl_p="-0.47" Cl_r="0.05" Cl_dr="0" Cl_da="0.22" />
     <!-- 023: Cn_b 0.03→0.07, Cn_r -0.015→-0.04.  Real HB1 has vertical fin
          behind motor — significantly more yaw stability than a pure flying wing.
          Comparable to sailplanes with fin (F3F=0.038, Pilatus=0.044). -->
-    <n Cn_b="0.07" Cn_p="-0.005" Cn_r="-0.04" Cn_dr="0"
+    <!-- 023 adjust4: adverse yaw and roll-yaw coupling.
+         Flight data (2026-04-03): mean 8.5° yaw change per roll event,
+         39 deg/s mean yaw rate during 0.5-0.8s roll events at ~500 deg/s.
+         Real yaw/roll ratio ≈ 0.078.
+
+         First attempt: Cn_da=-0.015, Cn_p=-0.012, Cl_b=-0.01 produced
+         yaw/roll ratio 0.314 (4x too high) — Cl_b too low let sideslip
+         build unchecked.
+
+         Revised: Cn_da=-0.010 (original), Cn_p=-0.008 (slight increase
+         from -0.005), Cl_b=-0.03 (moderate dihedral correction).
+         Target yaw/roll ratio ~0.08-0.12. -->
+    <n Cn_b="0.07" Cn_p="-0.008" Cn_r="-0.04" Cn_dr="0"
        Cn_da="-0.010" />
   </aero>
   <config version="1">

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -794,16 +794,26 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       return;
     }
 
-    // Capture temporal history before NN evaluation (for GETDPHI_PREV, GETDTHETA_PREV, GETDIST_PREV, etc.)
+    // Capture temporal history before NN evaluation (direction cosines, 023)
     {
       VectorPathProvider pathProvider(path, aircraftState.getThisPathIndex());
-      gp_scalar dPhi = executeGetDPhi(pathProvider, aircraftState, rabbitOdometer, 0.0f);
-      gp_scalar dTheta = executeGetDTheta(pathProvider, aircraftState, rabbitOdometer, 0.0f);
       gp_vec3 targetPos = getInterpolatedTargetPosition(
           pathProvider, rabbitOdometer, 0.0f);
-      gp_scalar distance = (targetPos - aircraftState.getPosition()).norm();
+      gp_vec3 craftToTarget = targetPos - aircraftState.getPosition();
+      gp_vec3 target_local = aircraftState.getOrientation().inverse() * craftToTarget;
+      float distance = static_cast<float>(target_local.norm());
+
+      // Path tangent for singularity fallback
+      gp_vec3 posAhead = getInterpolatedTargetPosition(pathProvider, rabbitOdometer, 0.5f);
+      gp_vec3 tangent = posAhead - targetPos;
+      double tn = tangent.norm();
+      gp_vec3 tangent_body = (tn > 1e-6)
+          ? aircraftState.getOrientation().inverse() * (tangent / tn)
+          : gp_vec3::UnitX();
+
+      gp_vec3 dir = computeTargetDir(target_local, distance, tangent_body);
       aircraftState.setRabbitPosition(targetPos);
-      aircraftState.recordErrorHistory(dPhi, dTheta, distance, simTimeMsec);
+      aircraftState.recordErrorHistory(dir, distance, simTimeMsec);
     }
 
     // Evaluate NN controller

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -309,25 +309,6 @@ int T_TX_InterfaceAUTOC::init(SimpleXMLTransfer *config)
     std::cerr << "[AUTOC] EngageDelayMsec=" << engageDelayMsec << std::endl;
   }
 
-  // RC smoothing filter: pt3 LPF matching INAV rc_filter_lpf_hz
-  {
-    const char* env = std::getenv("AUTOC_RC_FILTER_HZ");
-    if (env && *env != '\0') {
-      rcFilterHz = atoi(env);
-    }
-    // Compute filter gain k from cutoff frequency and FDM dt.
-    // FDM dt is from autoc_config.xml <flightModel dt="0.003" />
-    // k = dT / (RC + dT) where RC = 1 / (2 * orderCutoffCorrection * pi * f_cut)
-    // orderCutoffCorrection for 3rd order = 1/sqrt(2^(1/3) - 1) ≈ 1.9615
-    if (rcFilterHz > 0) {
-      float dT = 0.003f;  // FDM timestep from autoc_config.xml
-      float correction = 1.0f / sqrtf(powf(2.0f, 1.0f / 3.0f) - 1.0f);
-      float RC = 1.0f / (2.0f * correction * static_cast<float>(M_PI) * rcFilterHz);
-      rcFilterK = dT / (RC + dT);
-    }
-    std::cerr << "[AUTOC] RCFilterHz=" << rcFilterHz << " k=" << rcFilterK << std::endl;
-  }
-
   T_TX_Interface::init(config);
 
   socket_ = new TcpSocket();
@@ -520,10 +501,6 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
           (engageDelayMsec + gEvalUpdateIntervalMsec - 1) / gEvalUpdateIntervalMsec);
       engageCoastThrottle = static_cast<gp_scalar>(
           CLAMP_DEF(2.0 * (activeScenario.entrySpeedFactor - 1.0), -1.0, 1.0));
-      // Pre-fill RC filters with engage delay commands (no transient on first frame)
-      rcFilterPitch.reset(0.0f);
-      rcFilterRoll.reset(0.0f);
-      rcFilterThrottle.reset(engageCoastThrottle);
       gAcroIntegralRoll = gAcroIntegralPitch = gAcroIntegralYaw = 0.0;
       gAcroLastTimeMsec = 0;
       gCurrentPhysicsTrace.clear();  // Clear physics trace for new path
@@ -1082,29 +1059,10 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
   // Gyro rates are still provided as NN inputs (AircraftState.gyroRates_)
   // but the NN learns to use them for its own stabilization, not through a PID.
 
-  // RC smoothing filter: pt3 applied every FDM frame (~333Hz), smooths the
-  // 10Hz NN command steps.  Replicates INAV rc_filter_lpf_hz on all channels.
-  // When disabled (rcFilterHz=0), passes through unfiltered.
-  float filteredPitch, filteredRoll, filteredThrottle;
-  if (rcFilterK > 0.0f) {
-    filteredPitch    = rcFilterPitch.apply(pitchCommand, rcFilterK);
-    filteredRoll     = rcFilterRoll.apply(rollCommand, rcFilterK);
-    filteredThrottle = rcFilterThrottle.apply(throttleCommand, rcFilterK);
-  } else {
-    filteredPitch    = pitchCommand;
-    filteredRoll     = rollCommand;
-    filteredThrottle = throttleCommand;
-  }
-
-  // Store filtered values in AircraftState for data.dat logging
-  aircraftState.setFilteredPitchCommand(filteredPitch);
-  aircraftState.setFilteredRollCommand(filteredRoll);
-  aircraftState.setFilteredThrottleCommand(filteredThrottle);
-
-  // convert filtered values to crrcsim scales and return every frame
-  inputs->elevator = -filteredPitch / 2.0;         // invert from -1:1 to -0.5:0.5 (crrcsim convention)
-  inputs->aileron = filteredRoll / 2.0;            // from -1:1 to -0.5:0.5
-  inputs->throttle = filteredThrottle / 2.0 + 0.5; // from -1:1 to 0:1
+  // convert cached values to crrcsim scales and return every frame
+  inputs->elevator = -pitchCommand / 2.0;         // invert from -1:1 to -0.5:0.5 (crrcsim convention)
+  inputs->aileron = rollCommand / 2.0;            // from -1:1 to -0.5:0.5
+  inputs->throttle = throttleCommand / 2.0 + 0.5; // from -1:1 to 0:1
 
 #ifdef DETAILED_LOGGING
   {

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -309,6 +309,25 @@ int T_TX_InterfaceAUTOC::init(SimpleXMLTransfer *config)
     std::cerr << "[AUTOC] EngageDelayMsec=" << engageDelayMsec << std::endl;
   }
 
+  // RC smoothing filter: pt3 LPF matching INAV rc_filter_lpf_hz
+  {
+    const char* env = std::getenv("AUTOC_RC_FILTER_HZ");
+    if (env && *env != '\0') {
+      rcFilterHz = atoi(env);
+    }
+    // Compute filter gain k from cutoff frequency and FDM dt.
+    // FDM dt is from autoc_config.xml <flightModel dt="0.003" />
+    // k = dT / (RC + dT) where RC = 1 / (2 * orderCutoffCorrection * pi * f_cut)
+    // orderCutoffCorrection for 3rd order = 1/sqrt(2^(1/3) - 1) ≈ 1.9615
+    if (rcFilterHz > 0) {
+      float dT = 0.003f;  // FDM timestep from autoc_config.xml
+      float correction = 1.0f / sqrtf(powf(2.0f, 1.0f / 3.0f) - 1.0f);
+      float RC = 1.0f / (2.0f * correction * static_cast<float>(M_PI) * rcFilterHz);
+      rcFilterK = dT / (RC + dT);
+    }
+    std::cerr << "[AUTOC] RCFilterHz=" << rcFilterHz << " k=" << rcFilterK << std::endl;
+  }
+
   T_TX_Interface::init(config);
 
   socket_ = new TcpSocket();
@@ -501,6 +520,10 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
           (engageDelayMsec + gEvalUpdateIntervalMsec - 1) / gEvalUpdateIntervalMsec);
       engageCoastThrottle = static_cast<gp_scalar>(
           CLAMP_DEF(2.0 * (activeScenario.entrySpeedFactor - 1.0), -1.0, 1.0));
+      // Pre-fill RC filters with engage delay commands (no transient on first frame)
+      rcFilterPitch.reset(0.0f);
+      rcFilterRoll.reset(0.0f);
+      rcFilterThrottle.reset(engageCoastThrottle);
       gAcroIntegralRoll = gAcroIntegralPitch = gAcroIntegralYaw = 0.0;
       gAcroLastTimeMsec = 0;
       gCurrentPhysicsTrace.clear();  // Clear physics trace for new path
@@ -1059,10 +1082,29 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
   // Gyro rates are still provided as NN inputs (AircraftState.gyroRates_)
   // but the NN learns to use them for its own stabilization, not through a PID.
 
-  // convert cached values to crrcsim scales and return every frame
-  inputs->elevator = -pitchCommand / 2.0;         // invert from -1:1 to -0.5:0.5 (crrcsim convention)
-  inputs->aileron = rollCommand / 2.0;            // from -1:1 to -0.5:0.5
-  inputs->throttle = throttleCommand / 2.0 + 0.5; // from -1:1 to 0:1
+  // RC smoothing filter: pt3 applied every FDM frame (~333Hz), smooths the
+  // 10Hz NN command steps.  Replicates INAV rc_filter_lpf_hz on all channels.
+  // When disabled (rcFilterHz=0), passes through unfiltered.
+  float filteredPitch, filteredRoll, filteredThrottle;
+  if (rcFilterK > 0.0f) {
+    filteredPitch    = rcFilterPitch.apply(pitchCommand, rcFilterK);
+    filteredRoll     = rcFilterRoll.apply(rollCommand, rcFilterK);
+    filteredThrottle = rcFilterThrottle.apply(throttleCommand, rcFilterK);
+  } else {
+    filteredPitch    = pitchCommand;
+    filteredRoll     = rollCommand;
+    filteredThrottle = throttleCommand;
+  }
+
+  // Store filtered values in AircraftState for data.dat logging
+  aircraftState.setFilteredPitchCommand(filteredPitch);
+  aircraftState.setFilteredRollCommand(filteredRoll);
+  aircraftState.setFilteredThrottleCommand(filteredThrottle);
+
+  // convert filtered values to crrcsim scales and return every frame
+  inputs->elevator = -filteredPitch / 2.0;         // invert from -1:1 to -0.5:0.5 (crrcsim convention)
+  inputs->aileron = filteredRoll / 2.0;            // from -1:1 to -0.5:0.5
+  inputs->throttle = filteredThrottle / 2.0 + 0.5; // from -1:1 to 0:1
 
 #ifdef DETAILED_LOGGING
   {

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -299,6 +299,16 @@ int T_TX_InterfaceAUTOC::init(SimpleXMLTransfer *config)
   // Allow runtime override of NN eval cadence and compute latency (sim time).
   gEvalUpdateIntervalMsec = parseIntervalFromEnv("AUTOC_EVAL_INTERVAL_MSEC", EVAL_UPDATE_INTERVAL_MSEC_DEFAULT);
   gComputeLatencyMsec = parseIntervalFromEnv("AUTOC_COMPUTE_LATENCY_MSEC", COMPUTE_LATENCY_MSEC_DEFAULT);
+
+  // Engage delay: coast time before NN outputs reach surfaces (models INAV handoff)
+  {
+    const char* env = std::getenv("AUTOC_ENGAGE_DELAY_MSEC");
+    if (env && *env != '\0') {
+      engageDelayMsec = strtoul(env, nullptr, 10);
+    }
+    std::cerr << "[AUTOC] EngageDelayMsec=" << engageDelayMsec << std::endl;
+  }
+
   T_TX_Interface::init(config);
 
   socket_ = new TcpSocket();
@@ -485,11 +495,12 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       }
       gPendingCommand = PendingCommand{};
       aircraftStates.clear();
-      aircraftState.clearHistory();  // Reset temporal history for new path
-      // Reset commands for new path (NN needs zero-start per path, not per tick)
-      aircraftState.setPitchCommand(0.0f);
-      aircraftState.setRollCommand(0.0f);
-      aircraftState.setThrottleCommand(0.0f);
+      // Engage delay: coast for N ticks before NN outputs reach surfaces.
+      // Coast throttle derived from entry speed variation.
+      engageDelayTicksRemaining = static_cast<int>(
+          (engageDelayMsec + gEvalUpdateIntervalMsec - 1) / gEvalUpdateIntervalMsec);
+      engageCoastThrottle = static_cast<gp_scalar>(
+          CLAMP_DEF(2.0 * (activeScenario.entrySpeedFactor - 1.0), -1.0, 1.0));
       gAcroIntegralRoll = gAcroIntegralPitch = gAcroIntegralYaw = 0.0;
       gAcroLastTimeMsec = 0;
       gCurrentPhysicsTrace.clear();  // Clear physics trace for new path
@@ -546,7 +557,27 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
                                  static_cast<gp_scalar>(0.0f), static_cast<gp_scalar>(0.0f), static_cast<gp_scalar>(0.0f), 0};
       initialState.setRabbitPosition(path[0].start);
       initialState.setRabbitSpeed(crrcsimRabbitSpeed);
-      aircraftStates.push_back(initialState);
+
+      // Copy initial state to the global aircraftState BEFORE history pre-fill
+      // so resetHistory() uses the correct position/orientation (not leftover
+      // from the previous scenario).
+      aircraftState = initialState;
+
+      // Pre-fill history buffer with initial geometry so the NN starts with
+      // consistent direction cosines instead of zeros.
+      {
+        gp_vec3 tangent;
+        if (path.size() > 1)
+          tangent = path[1].start - path[0].start;
+        else
+          tangent = gp_vec3::UnitX();
+        double tn = tangent.norm();
+        if (tn > 1e-6) tangent = tangent / tn;
+        else tangent = gp_vec3::UnitX();
+        aircraftState.resetHistory(path[0].start, tangent);
+      }
+
+      aircraftStates.push_back(aircraftState);
       if (debugSamplesCurrentPath.empty()) {
         DebugSample sample;
         sample.pathIndex = pathSelector;
@@ -973,10 +1004,20 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       debugSamplesCurrentPath.push_back(sample);
     }
 
-    // Stage commands to be applied after compute latency
-    gPendingCommand.pitch = aircraftState.getPitchCommand();
-    gPendingCommand.roll = aircraftState.getRollCommand();
-    gPendingCommand.throttle = aircraftState.getThrottleCommand();
+    // Stage commands to be applied after compute latency.
+    // During engage delay window: hold stick centered (pitch/roll=0) with
+    // cruise throttle derived from entry speed variation — aircraft coasts
+    // on momentum, matching real handoff.
+    if (engageDelayTicksRemaining > 0) {
+      gPendingCommand.pitch = 0.0f;
+      gPendingCommand.roll = 0.0f;
+      gPendingCommand.throttle = engageCoastThrottle;
+      engageDelayTicksRemaining--;
+    } else {
+      gPendingCommand.pitch = aircraftState.getPitchCommand();
+      gPendingCommand.roll = aircraftState.getRollCommand();
+      gPendingCommand.throttle = aircraftState.getThrottleCommand();
+    }
     gPendingCommand.readyTimeMsec = simTimeMsec + gComputeLatencyMsec;
     gPendingCommand.valid = true;
 

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -49,6 +49,7 @@ using namespace std;
 #define FEET_TO_METERS 0.3048
 #define EVAL_UPDATE_INTERVAL_MSEC_DEFAULT 100   // Sensor+NN cadence (~10Hz)
 #define COMPUTE_LATENCY_MSEC_DEFAULT 30         // Bench-measured: consolidated MSP fetch(12)+eval(5)+send(12)=29ms
+#define ENGAGE_DELAY_MSEC_DEFAULT 750           // Measured INAV MANUAL→autoc handoff delay (2026-04-07 flight)
 #define SIM_FPS 25.0                            // ~40 Hz physics tick assumption for overflow calc
 
 // ACRO mode rate PID — converts NN rate commands to surface deflections
@@ -157,6 +158,12 @@ private:
   int workerPid = 0;
 
   int evalCounter = 0;  // Total evaluations this worker has processed
+
+  // Engage delay window — simulates INAV handoff delay (NN runs but stick
+  // is held at {0,0,cruise_throttle} for the first N ticks of each scenario).
+  int engageDelayTicksRemaining = 0;
+  unsigned long engageDelayMsec = ENGAGE_DELAY_MSEC_DEFAULT;
+  gp_scalar engageCoastThrottle = 0.0f;  // set per-scenario from entrySpeedFactor
 
   // NN controller
   NNGenome nnGenome;

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -50,7 +50,6 @@ using namespace std;
 #define EVAL_UPDATE_INTERVAL_MSEC_DEFAULT 100   // Sensor+NN cadence (~10Hz)
 #define COMPUTE_LATENCY_MSEC_DEFAULT 30         // Bench-measured: consolidated MSP fetch(12)+eval(5)+send(12)=29ms
 #define ENGAGE_DELAY_MSEC_DEFAULT 750           // Measured INAV MANUAL→autoc handoff delay (2026-04-07 flight)
-#define RC_FILTER_HZ_DEFAULT 20                 // pt3 LPF cutoff — matches INAV rc_filter_lpf_hz setting
 #define SIM_FPS 25.0                            // ~40 Hz physics tick assumption for overflow calc
 
 // ACRO mode rate PID — converts NN rate commands to surface deflections
@@ -165,23 +164,6 @@ private:
   int engageDelayTicksRemaining = 0;
   unsigned long engageDelayMsec = ENGAGE_DELAY_MSEC_DEFAULT;
   gp_scalar engageCoastThrottle = 0.0f;  // set per-scenario from entrySpeedFactor
-
-  // RC smoothing filter — pt3 (3rd-order cascade), replicates INAV rc_smoothing.c
-  // Runs every getInputData() call (FDM rate ~333Hz), smooths NN command steps.
-  // Applied to pitch, roll, throttle before FDM surface conversion.
-  struct Pt3Filter {
-    float state1 = 0, state2 = 0, state = 0;
-    float apply(float input, float k) {
-      state1 += k * (input - state1);
-      state2 += k * (state1 - state2);
-      state  += k * (state2 - state);
-      return state;
-    }
-    void reset(float val) { state1 = state2 = state = val; }
-  };
-  Pt3Filter rcFilterPitch, rcFilterRoll, rcFilterThrottle;
-  float rcFilterK = 0.0f;       // filter gain, computed from cutoff freq + FDM dt
-  int rcFilterHz = RC_FILTER_HZ_DEFAULT;  // cutoff frequency (0 = disabled)
 
   // NN controller
   NNGenome nnGenome;

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -32,6 +32,7 @@
 #include "autoc/nn/evaluator.h"
 #include "autoc/nn/serialization.h"
 #include "autoc/eval/sensor_math.h"
+#include "autoc/nn/nn_input_computation.h"
 #include "autoc/eval/variation_generator.h"
 #include "autoc/util/socket_wrapper.h"
 

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -50,6 +50,7 @@ using namespace std;
 #define EVAL_UPDATE_INTERVAL_MSEC_DEFAULT 100   // Sensor+NN cadence (~10Hz)
 #define COMPUTE_LATENCY_MSEC_DEFAULT 30         // Bench-measured: consolidated MSP fetch(12)+eval(5)+send(12)=29ms
 #define ENGAGE_DELAY_MSEC_DEFAULT 750           // Measured INAV MANUAL→autoc handoff delay (2026-04-07 flight)
+#define RC_FILTER_HZ_DEFAULT 20                 // pt3 LPF cutoff — matches INAV rc_filter_lpf_hz setting
 #define SIM_FPS 25.0                            // ~40 Hz physics tick assumption for overflow calc
 
 // ACRO mode rate PID — converts NN rate commands to surface deflections
@@ -164,6 +165,23 @@ private:
   int engageDelayTicksRemaining = 0;
   unsigned long engageDelayMsec = ENGAGE_DELAY_MSEC_DEFAULT;
   gp_scalar engageCoastThrottle = 0.0f;  // set per-scenario from entrySpeedFactor
+
+  // RC smoothing filter — pt3 (3rd-order cascade), replicates INAV rc_smoothing.c
+  // Runs every getInputData() call (FDM rate ~333Hz), smooths NN command steps.
+  // Applied to pitch, roll, throttle before FDM surface conversion.
+  struct Pt3Filter {
+    float state1 = 0, state2 = 0, state = 0;
+    float apply(float input, float k) {
+      state1 += k * (input - state1);
+      state2 += k * (state1 - state2);
+      state  += k * (state2 - state);
+      return state;
+    }
+    void reset(float val) { state1 = state2 = state = val; }
+  };
+  Pt3Filter rcFilterPitch, rcFilterRoll, rcFilterThrottle;
+  float rcFilterK = 0.0f;       // filter gain, computed from cutoff freq + FDM dt
+  int rcFilterHz = RC_FILTER_HZ_DEFAULT;  // cutoff frequency (0 = disabled)
 
   // NN controller
   NNGenome nnGenome;


### PR DESCRIPTION
## Summary

Paired with parent autoc PR https://github.com/gcmcnutt/autoc/pull/1.

- **CRRCSim ↔ autoc bridge** (`inputdev_autoc.cpp`): engage delay window with stick-centered + cruise-throttle hold; direction-cosine history recording via `computeTargetDir()`; throttle baseline derived from speed variation.
- **hb1_streamer.xml FDM tuning**: adjust1..4 — CD_prof, F, CG_arm, CL_drop, Cl_da, Cl_b, Cn_b, Cn_p, Cn_r iterated against flight data to improve sim-to-real fidelity.
- **pt3 RC smoothing filter**: implemented replicating INAV's `rc_filter_lpf_hz`, then reverted — it stunted training convergence without the smoothness payoff we'd hoped for. Abandoned cleanly.

## Commits (6)

- `5406c95` feat(023): hb1-adjust4 dynamics — Cl_b -0.05, Cn_p -0.008, yaw/roll coupling tuning
- `23dbc95` feat(023): hb1-adjust3 dynamics — CD_prof 0.15, F 7.5, CG_arm 0.28, CL_drop 0.15
- `435ad94` revert(023): remove pt3 RC smoothing filter — stunts training convergence
- `9032e56` feat(023): pt3 RC smoothing filter replicating INAV rc_filter_lpf_hz
- `b655101` feat(023): engage delay window + history pre-fill + throttle from speed variation
- `82153c0` feat(023): direction cosines in history recording (Phase 0a.2)

## Flight-20260417 context

This submodule's FDM tuning (adjust1..4) contributed to the 023 NN training run that flew on 2026-04-17. Post-flight analysis in the parent autoc repo (PR #1) surfaced two items for 024:

- Sim data.dat cadence lands on 117 ms/sample instead of 100 ms — CRRCSim physics tick combined with strict-greater eval threshold in `inputdev_autoc.cpp:341`. Will be fixed in 024-sim-real-fidelity WI1.
- Flight pitch axis inverted between gyro and AHRS-quat (sim is clean — this submodule's output matches expectations). Root cause hypothesized on the xiao/INAV side in autoc WI5.

## Test plan

- [x] CRRCSim builds and links against autoc
- [x] hb1_streamer.xml renders correctly in CRRCSim GUI
- [x] Training runs hb1-adjust1..4 complete and pass autoc eval suite
- [x] Direction cosine history recording verified via sim data.dat analysis (unit-vector invariant holds)

Merge order: this submodule first, then parent autoc PR #1 with submodule pointer bump if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)