### PR TITLE
027: recurrent NN controller hook + ACRO PID nullify

### DIFF
--- a/autoc_config.xml
+++ b/autoc_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <crrcsimConfig version="2">
-  <video enabled="0" color_depth="8" multisamples="0" fps="25">
+  <video enabled="0" color_depth="8" multisamples="0" fps="20">
     <skybox texture_offset="0.00000" />
     <fullscreen fUse="0" />
     <zoom field_of_view="35" autozoom="0.050000001" />
@@ -154,7 +154,7 @@
   <windVectors fUse="0" />
   <modelViewWindow fUse="2" />
   <simulation slowMotion="0" slowTimeScale="0.5">
-    <flightModel dt="0.003" />
+    <flightModel dt="0.005" />
     <display_mode fUse="0" />
   </simulation>
   <!-- Point sim at streamer-tuned HB1 to mirror current test setup -->

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -470,6 +470,11 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
         return;
       }
 
+      // Build/rebuild the NN controller for the new genome. Recurrent
+      // hidden state (spec 027) lives inside the backend and is reset
+      // per-span below.
+      nnController_ = std::make_unique<NNControllerBackend>(nnGenome);
+
       // Cache quat dot past reset
       quatDotPast[0] = quatDotPast[1] = quatDotPast[2] = quatDotPast[3] = 0.0;
       return;
@@ -529,6 +534,9 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
           (engageDelayMsec + gEvalUpdateIntervalMsec - 1) / gEvalUpdateIntervalMsec);
       engageCoastThrottle = static_cast<gp_scalar>(
           CLAMP_DEF(2.0 * (activeScenario.entrySpeedFactor - 1.0), -1.0, 1.0));
+      // Zero recurrent NN state at span start (spec 027 Q4: h_t resets
+      // on new scenario; no-op for feedforward genomes).
+      if (nnController_) nnController_->reset();
       gCurrentPhysicsTrace.clear();  // Clear physics trace for new path
 
       // Set worker identity globals for FDM trace capture
@@ -873,11 +881,13 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       aircraftState.recordErrorHistory(dir, distance, simTimeMsec);
     }
 
-    // Evaluate NN controller
-    {
+    // Evaluate NN controller. Use the per-span member `nnController_` so
+    // recurrent hidden state (spec 027) persists across ticks. Fired on
+    // NN-eval cadence only — the `shouldEval` gate above enforces this,
+    // matching clarify Q4's hidden-state-advances-on-NN-tick contract.
+    if (nnController_) {
       VectorPathProvider pathProvider(path, aircraftState.getThisPathIndex());
-      NNControllerBackend nnBackend(nnGenome);
-      nnBackend.evaluate(aircraftState, pathProvider);
+      nnController_->evaluate(aircraftState, pathProvider);
     }
 
     // Save post-eval state for results

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -96,12 +96,6 @@ static double gAcroIntegralPitch = 0.0;
 static double gAcroIntegralYaw = 0.0;
 static unsigned long gAcroLastTimeMsec = 0;
 
-unsigned long getCycleCounterOverflow() {
-  // a few cycles after the last update, we assume crash, no flight updates, etc
-  unsigned long overflow = static_cast<unsigned long>(SIM_FPS * gEvalUpdateIntervalMsec / 1000.0);
-  return overflow > 0 ? overflow : 1;
-}
-
 static bool gInDeterministicTest = false;
 
 // Global aircraftState used by NN evaluation (was in autoc-eval.cc)
@@ -309,6 +303,39 @@ int T_TX_InterfaceAUTOC::init(SimpleXMLTransfer *config)
     std::cerr << "[AUTOC] EngageDelayMsec=" << engageDelayMsec << std::endl;
   }
 
+  // Compute frame-counter cadence triple and enforce integrality at startup.
+  // Constraint: outer cycleLength_ms must divide gEvalUpdateIntervalMsec
+  // exactly. CTime already rounds cycleLength to a multiple of
+  // (Global::dt * 1000). See spec 024 WI4.
+  {
+    isHeadless = (config->getInt("video.enabled", 1) == 0);
+    SimpleXMLTransfer* video = config->getChild("video", true);
+    const int fps = video->attributeAsInt("fps", 0);
+    const double dtMs = 1000.0 * static_cast<double>(Global::dt);
+    const unsigned long cycleLengthMs =
+      (fps > 0 && dtMs > 0.0)
+        ? static_cast<unsigned long>(static_cast<int>(1000.0 / fps / dtMs) * dtMs + 0.5)
+        : 0UL;
+    if (cycleLengthMs == 0 || gEvalUpdateIntervalMsec % cycleLengthMs != 0) {
+      std::cerr << "[AUTOC] FATAL: cadence triple not integral. "
+                << "video.fps=" << fps
+                << " Global::dt=" << Global::dt
+                << " cycleLengthMs=" << cycleLengthMs
+                << " gEvalUpdateIntervalMsec=" << gEvalUpdateIntervalMsec
+                << " — evalInterval must be an integer multiple of cycleLength."
+                << std::endl;
+      std::exit(1);
+    }
+    framesPerEval = gEvalUpdateIntervalMsec / cycleLengthMs;
+    std::cerr << "[AUTOC] cadence: video.fps=" << fps
+              << " dt=" << Global::dt
+              << " cycleLengthMs=" << cycleLengthMs
+              << " evalIntervalMsec=" << gEvalUpdateIntervalMsec
+              << " framesPerEval=" << framesPerEval
+              << " headless=" << (isHeadless ? "true" : "false")
+              << std::endl;
+  }
+
   T_TX_Interface::init(config);
 
   socket_ = new TcpSocket();
@@ -337,8 +364,15 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
   diagIndex = (diagIndex + 1) % DIAG_BUFFER_SIZE;
   if (diagCount < DIAG_BUFFER_SIZE) diagCount++;
 
-  const unsigned long overflowLimit = getCycleCounterOverflow();
-  bool shouldEval = (simTimeMsec > lastUpdateTimeMsec + gEvalUpdateIntervalMsec) || (++cycleCounter > overflowLimit);
+  // Frame-counter cadence (both headless and video):
+  //  - Outer frame is a fixed cycleLength_ms (CTime). framesPerEval was
+  //    validated at init to divide gEvalUpdateIntervalMsec exactly, so every
+  //    framesPerEval-th outer frame fires eval with zero drift.
+  //  - simTimeMsec is stamped into diagBuffer for drift logging in video mode.
+  //  - A "way late" stall (wall-clock pause in video mode, computer hiccup,
+  //    etc.) shows up as a simTime leap > SIM_MAX_INTERVAL_MSEC and is caught
+  //    by the jump reset below, which clears counters and bookkeeping.
+  bool shouldEval = (++cycleCounter >= framesPerEval);
   if (shouldEval)
   {
 #ifdef DETAILED_LOGGING

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -96,6 +96,21 @@ static double gAcroIntegralPitch = 0.0;
 static double gAcroIntegralYaw = 0.0;
 static unsigned long gAcroLastTimeMsec = 0;
 
+// ACRO inner-loop filter state — 1-pole LPF on body rate feeding PID error.
+// Applied at PID tick rate (outer-frame, ~20 Hz). See ACRO_GYRO_LPF_HZ.
+// Yaw not wired; HB1 has no controllable rudder (spec 026 clarification Q3).
+static double gAcroGyroLpfP = 0.0;   // filtered body-X rate (roll)
+static double gAcroGyroLpfQ = 0.0;   // filtered body-Y rate (pitch)
+static bool   gAcroGyroLpfPrimed = false;
+
+// ACRO D-term PT2 biquad state. Dormant while D gain = 0; kept here so the
+// filter can be activated by setting ACRO_D_ROLL / ACRO_D_PITCH nonzero
+// without restructuring. See ACRO_DTERM_LPF_HZ.
+static double gAcroDtermPrevErrRoll = 0.0;
+static double gAcroDtermPrevErrPitch = 0.0;
+static double gAcroDtermStage1Roll = 0.0, gAcroDtermStage2Roll = 0.0;
+static double gAcroDtermStage1Pitch = 0.0, gAcroDtermStage2Pitch = 0.0;
+
 static bool gInDeterministicTest = false;
 
 // Global aircraftState used by NN evaluation (was in autoc-eval.cc)
@@ -537,6 +552,13 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
           CLAMP_DEF(2.0 * (activeScenario.entrySpeedFactor - 1.0), -1.0, 1.0));
       gAcroIntegralRoll = gAcroIntegralPitch = gAcroIntegralYaw = 0.0;
       gAcroLastTimeMsec = 0;
+      // ACRO inner-loop filter state reset — primed on first measurement
+      // to avoid initial ramp-up from zero.
+      gAcroGyroLpfP = gAcroGyroLpfQ = 0.0;
+      gAcroGyroLpfPrimed = false;
+      gAcroDtermPrevErrRoll = gAcroDtermPrevErrPitch = 0.0;
+      gAcroDtermStage1Roll = gAcroDtermStage2Roll = 0.0;
+      gAcroDtermStage1Pitch = gAcroDtermStage2Pitch = 0.0;
       gCurrentPhysicsTrace.clear();  // Clear physics trace for new path
 
       // Set worker identity globals for FDM trace capture
@@ -1087,11 +1109,93 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
     gPendingCommand.valid = false;
   }
 
-  // ACRO rate PID is DISABLED — NN outputs go directly to surfaces (MANUAL mode).
-  // The PID code is preserved in git history (021 branch) for future use.
-  // Current mode: NN output [-1,1] → direct surface deflection, same as 020.
-  // Gyro rates are still provided as NN inputs (AircraftState.gyroRates_)
-  // but the NN learns to use them for its own stabilization, not through a PID.
+  // ACRO rate PID — converts NN rate commands to surface deflections.
+  // NN output `pitchCommand` / `rollCommand` is desired body rate fraction
+  // ([-1, +1] × ACRO_MAX_RATE_* → rad/s). FF + P + I on rate error, no D
+  // initially. Output normalized to [-1, +1] by ACRO_PID_SCALE, then
+  // bridged to crrcsim surface conventions below. Pitch and roll only —
+  // yaw stays passive (HB1 has no controllable rudder; see spec
+  // specs/026-nn-temporal-state/spec.md clarification Q3). Throttle
+  // passthrough unchanged.
+  //
+  // All rate math in rad/s, matching FDM (getOmegaBody), AircraftState
+  // gyroRates_, and COORDINATE_CONVENTIONS.md. Re-enables the 021 design
+  // that was shelved on 2026-04-07; see spec 026 and research § "Sim PID
+  // implementation notes" for rationale.
+  {
+    EOM01* eom01_acro = dynamic_cast<EOM01*>(Global::aircraft->getFDM());
+    if (eom01_acro) {
+      CRRCMath::Vector3 omega = eom01_acro->getOmegaBody();  // rad/s
+      double pRadS = omega(0);  // roll rate
+      double qRadS = omega(1);  // pitch rate
+
+      // dt for integrator + LPF. getInputData fires once per outer frame
+      // (cycleLength_ms); fallback to 50 ms if clock hasn't been set yet.
+      double dt = (gAcroLastTimeMsec > 0 && simTimeMsec > gAcroLastTimeMsec)
+                  ? (simTimeMsec - gAcroLastTimeMsec) / 1000.0
+                  : 0.050;
+      gAcroLastTimeMsec = simTimeMsec;
+
+      // 1-pole LPF on measured rate before PID error. Prime to first sample
+      // on span start to avoid ramp-up from zero.
+      if (!gAcroGyroLpfPrimed) {
+        gAcroGyroLpfP = pRadS;
+        gAcroGyroLpfQ = qRadS;
+        gAcroGyroLpfPrimed = true;
+      } else {
+        const double alpha = std::exp(-2.0 * M_PI * ACRO_GYRO_LPF_HZ * dt);
+        gAcroGyroLpfP = alpha * gAcroGyroLpfP + (1.0 - alpha) * pRadS;
+        gAcroGyroLpfQ = alpha * gAcroGyroLpfQ + (1.0 - alpha) * qRadS;
+      }
+
+      // NN commands [-1,1] → desired rates (rad/s)
+      const double maxRollRadS  = ACRO_MAX_RATE_ROLL  * M_PI / 180.0;
+      const double maxPitchRadS = ACRO_MAX_RATE_PITCH * M_PI / 180.0;
+      const double desiredRoll  = rollCommand  * maxRollRadS;
+      const double desiredPitch = pitchCommand * maxPitchRadS;
+
+      // Single-axis FF+P+I via shared helper (see autoc/eval/acro_pid.h).
+      const AcroPidGains gainsRoll{ACRO_FF_ROLL,  ACRO_P_ROLL,  ACRO_I_ROLL,  ACRO_PID_SCALE};
+      const AcroPidGains gainsPitch{ACRO_FF_PITCH, ACRO_P_PITCH, ACRO_I_PITCH, ACRO_PID_SCALE};
+      const AcroPidResult resRoll  = acroPidStep(gainsRoll,
+          {desiredRoll,  gAcroGyroLpfP, dt}, gAcroIntegralRoll,  10.0);
+      const AcroPidResult resPitch = acroPidStep(gainsPitch,
+          {desiredPitch, gAcroGyroLpfQ, dt}, gAcroIntegralPitch, 10.0);
+      gAcroIntegralRoll  = resRoll.newIntegral;
+      gAcroIntegralPitch = resPitch.newIntegral;
+
+      // Track rate errors for a future D-term without affecting behavior now.
+      gAcroDtermPrevErrRoll  = resRoll.error;
+      gAcroDtermPrevErrPitch = resPitch.error;
+
+      // Replace NN rate commands with PID surface outputs, clamped.
+      pitchCommand = resPitch.clamped;
+      rollCommand  = resRoll.clamped;
+      // throttle passes through directly (INAV ACRO is also throttle-passthrough)
+
+      // Snapshot PID internals onto the most-recent AircraftState push
+      // so autoc can render them into data.dat. PID terms are post-scale
+      // so summing FF+P+I reproduces the (pre-clamp) surface output.
+      if (!aircraftStates.empty()) {
+        PidInternals pid;
+        pid.rateCmdP = static_cast<float>(desiredRoll);
+        pid.rateCmdQ = static_cast<float>(desiredPitch);
+        pid.rateAchP = static_cast<float>(pRadS);
+        pid.rateAchQ = static_cast<float>(qRadS);
+        pid.ffP = static_cast<float>(resRoll.ffTerm);
+        pid.ffQ = static_cast<float>(resPitch.ffTerm);
+        pid.pP  = static_cast<float>(resRoll.pTerm);
+        pid.pQ  = static_cast<float>(resPitch.pTerm);
+        pid.iP  = static_cast<float>(resRoll.iTerm);
+        pid.iQ  = static_cast<float>(resPitch.iTerm);
+        pid.intP = static_cast<float>(resRoll.newIntegral);
+        pid.intQ = static_cast<float>(resPitch.newIntegral);
+        pid.sat = (resPitch.saturated ? 0x1 : 0)
+                | (resRoll.saturated  ? 0x2 : 0);
+        aircraftStates.back().setPidInternals(pid);
+      }
+    }
+  }
 
   // convert cached values to crrcsim scales and return every frame
   inputs->elevator = -pitchCommand / 2.0;         // invert from -1:1 to -0.5:0.5 (crrcsim convention)

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -90,27 +90,6 @@ ScenarioMetadata scenarioForPathIndex(const EvalData& evalData, size_t idx) {
 unsigned long gEvalUpdateIntervalMsec = EVAL_UPDATE_INTERVAL_MSEC_DEFAULT;   // sensor/NN cadence
 unsigned long gComputeLatencyMsec = COMPUTE_LATENCY_MSEC_DEFAULT;           // simulated NN compute latency (sensor→output)
 
-// ACRO mode rate PID state
-static double gAcroIntegralRoll = 0.0;
-static double gAcroIntegralPitch = 0.0;
-static double gAcroIntegralYaw = 0.0;
-static unsigned long gAcroLastTimeMsec = 0;
-
-// ACRO inner-loop filter state — 1-pole LPF on body rate feeding PID error.
-// Applied at PID tick rate (outer-frame, ~20 Hz). See ACRO_GYRO_LPF_HZ.
-// Yaw not wired; HB1 has no controllable rudder (spec 026 clarification Q3).
-static double gAcroGyroLpfP = 0.0;   // filtered body-X rate (roll)
-static double gAcroGyroLpfQ = 0.0;   // filtered body-Y rate (pitch)
-static bool   gAcroGyroLpfPrimed = false;
-
-// ACRO D-term PT2 biquad state. Dormant while D gain = 0; kept here so the
-// filter can be activated by setting ACRO_D_ROLL / ACRO_D_PITCH nonzero
-// without restructuring. See ACRO_DTERM_LPF_HZ.
-static double gAcroDtermPrevErrRoll = 0.0;
-static double gAcroDtermPrevErrPitch = 0.0;
-static double gAcroDtermStage1Roll = 0.0, gAcroDtermStage2Roll = 0.0;
-static double gAcroDtermStage1Pitch = 0.0, gAcroDtermStage2Pitch = 0.0;
-
 static bool gInDeterministicTest = false;
 
 // Global aircraftState used by NN evaluation (was in autoc-eval.cc)
@@ -550,15 +529,6 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
           (engageDelayMsec + gEvalUpdateIntervalMsec - 1) / gEvalUpdateIntervalMsec);
       engageCoastThrottle = static_cast<gp_scalar>(
           CLAMP_DEF(2.0 * (activeScenario.entrySpeedFactor - 1.0), -1.0, 1.0));
-      gAcroIntegralRoll = gAcroIntegralPitch = gAcroIntegralYaw = 0.0;
-      gAcroLastTimeMsec = 0;
-      // ACRO inner-loop filter state reset — primed on first measurement
-      // to avoid initial ramp-up from zero.
-      gAcroGyroLpfP = gAcroGyroLpfQ = 0.0;
-      gAcroGyroLpfPrimed = false;
-      gAcroDtermPrevErrRoll = gAcroDtermPrevErrPitch = 0.0;
-      gAcroDtermStage1Roll = gAcroDtermStage2Roll = 0.0;
-      gAcroDtermStage1Pitch = gAcroDtermStage2Pitch = 0.0;
       gCurrentPhysicsTrace.clear();  // Clear physics trace for new path
 
       // Set worker identity globals for FDM trace capture
@@ -1109,91 +1079,29 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
     gPendingCommand.valid = false;
   }
 
-  // ACRO rate PID — converts NN rate commands to surface deflections.
-  // NN output `pitchCommand` / `rollCommand` is desired body rate fraction
-  // ([-1, +1] × ACRO_MAX_RATE_* → rad/s). FF + P + I on rate error, no D
-  // initially. Output normalized to [-1, +1] by ACRO_PID_SCALE, then
-  // bridged to crrcsim surface conventions below. Pitch and roll only —
-  // yaw stays passive (HB1 has no controllable rudder; see spec
-  // specs/026-nn-temporal-state/spec.md clarification Q3). Throttle
-  // passthrough unchanged.
-  //
-  // All rate math in rad/s, matching FDM (getOmegaBody), AircraftState
-  // gyroRates_, and COORDINATE_CONVENTIONS.md. Re-enables the 021 design
-  // that was shelved on 2026-04-07; see spec 026 and research § "Sim PID
-  // implementation notes" for rationale.
+  // NN outputs are direct surface commands (unity pass-through). 026's
+  // external ACRO PID experiment went NO-GO — see
+  // specs/026-nn-temporal-state/findings.md. Only thing kept is
+  // observational diagnostic capture: rateCmd expresses what the NN
+  // output would mean as a body rate if a PID were active, rateAch is
+  // the actual body rate, FF term mirrors the unity command. P/I/integ
+  // all zero.
   {
     EOM01* eom01_acro = dynamic_cast<EOM01*>(Global::aircraft->getFDM());
-    if (eom01_acro) {
-      CRRCMath::Vector3 omega = eom01_acro->getOmegaBody();  // rad/s
-      double pRadS = omega(0);  // roll rate
-      double qRadS = omega(1);  // pitch rate
-
-      // dt for integrator + LPF. getInputData fires once per outer frame
-      // (cycleLength_ms); fallback to 50 ms if clock hasn't been set yet.
-      double dt = (gAcroLastTimeMsec > 0 && simTimeMsec > gAcroLastTimeMsec)
-                  ? (simTimeMsec - gAcroLastTimeMsec) / 1000.0
-                  : 0.050;
-      gAcroLastTimeMsec = simTimeMsec;
-
-      // 1-pole LPF on measured rate before PID error. Prime to first sample
-      // on span start to avoid ramp-up from zero.
-      if (!gAcroGyroLpfPrimed) {
-        gAcroGyroLpfP = pRadS;
-        gAcroGyroLpfQ = qRadS;
-        gAcroGyroLpfPrimed = true;
-      } else {
-        const double alpha = std::exp(-2.0 * M_PI * ACRO_GYRO_LPF_HZ * dt);
-        gAcroGyroLpfP = alpha * gAcroGyroLpfP + (1.0 - alpha) * pRadS;
-        gAcroGyroLpfQ = alpha * gAcroGyroLpfQ + (1.0 - alpha) * qRadS;
-      }
-
-      // NN commands [-1,1] → desired rates (rad/s)
+    if (eom01_acro && !aircraftStates.empty()) {
+      CRRCMath::Vector3 omega = eom01_acro->getOmegaBody();
       const double maxRollRadS  = ACRO_MAX_RATE_ROLL  * M_PI / 180.0;
       const double maxPitchRadS = ACRO_MAX_RATE_PITCH * M_PI / 180.0;
-      const double desiredRoll  = rollCommand  * maxRollRadS;
-      const double desiredPitch = pitchCommand * maxPitchRadS;
-
-      // Single-axis FF+P+I via shared helper (see autoc/eval/acro_pid.h).
-      const AcroPidGains gainsRoll{ACRO_FF_ROLL,  ACRO_P_ROLL,  ACRO_I_ROLL,  ACRO_PID_SCALE};
-      const AcroPidGains gainsPitch{ACRO_FF_PITCH, ACRO_P_PITCH, ACRO_I_PITCH, ACRO_PID_SCALE};
-      const AcroPidResult resRoll  = acroPidStep(gainsRoll,
-          {desiredRoll,  gAcroGyroLpfP, dt}, gAcroIntegralRoll,  10.0);
-      const AcroPidResult resPitch = acroPidStep(gainsPitch,
-          {desiredPitch, gAcroGyroLpfQ, dt}, gAcroIntegralPitch, 10.0);
-      gAcroIntegralRoll  = resRoll.newIntegral;
-      gAcroIntegralPitch = resPitch.newIntegral;
-
-      // Track rate errors for a future D-term without affecting behavior now.
-      gAcroDtermPrevErrRoll  = resRoll.error;
-      gAcroDtermPrevErrPitch = resPitch.error;
-
-      // Replace NN rate commands with PID surface outputs, clamped.
-      pitchCommand = resPitch.clamped;
-      rollCommand  = resRoll.clamped;
-      // throttle passes through directly (INAV ACRO is also throttle-passthrough)
-
-      // Snapshot PID internals onto the most-recent AircraftState push
-      // so autoc can render them into data.dat. PID terms are post-scale
-      // so summing FF+P+I reproduces the (pre-clamp) surface output.
-      if (!aircraftStates.empty()) {
-        PidInternals pid;
-        pid.rateCmdP = static_cast<float>(desiredRoll);
-        pid.rateCmdQ = static_cast<float>(desiredPitch);
-        pid.rateAchP = static_cast<float>(pRadS);
-        pid.rateAchQ = static_cast<float>(qRadS);
-        pid.ffP = static_cast<float>(resRoll.ffTerm);
-        pid.ffQ = static_cast<float>(resPitch.ffTerm);
-        pid.pP  = static_cast<float>(resRoll.pTerm);
-        pid.pQ  = static_cast<float>(resPitch.pTerm);
-        pid.iP  = static_cast<float>(resRoll.iTerm);
-        pid.iQ  = static_cast<float>(resPitch.iTerm);
-        pid.intP = static_cast<float>(resRoll.newIntegral);
-        pid.intQ = static_cast<float>(resPitch.newIntegral);
-        pid.sat = (resPitch.saturated ? 0x1 : 0)
-                | (resRoll.saturated  ? 0x2 : 0);
-        aircraftStates.back().setPidInternals(pid);
-      }
+      PidInternals pid;
+      pid.rateCmdP = static_cast<float>(rollCommand  * maxRollRadS);
+      pid.rateCmdQ = static_cast<float>(pitchCommand * maxPitchRadS);
+      pid.rateAchP = static_cast<float>(omega(0));
+      pid.rateAchQ = static_cast<float>(omega(1));
+      pid.ffP = static_cast<float>(rollCommand);
+      pid.ffQ = static_cast<float>(pitchCommand);
+      pid.sat = (std::abs(pitchCommand) >= 1.0 ? 0x1 : 0)
+              | (std::abs(rollCommand)  >= 1.0 ? 0x2 : 0);
+      aircraftStates.back().setPidInternals(pid);
     }
   }
 

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -40,6 +40,7 @@
 #include <iostream>
 #include <cmath>
 #include <array>
+#include <memory>
 #include <unistd.h>
 
 using namespace std;
@@ -137,8 +138,13 @@ private:
   unsigned long engageDelayMsec = ENGAGE_DELAY_MSEC_DEFAULT;
   gp_scalar engageCoastThrottle = 0.0f;  // set per-scenario from entrySpeedFactor
 
-  // NN controller
+  // NN controller. `nnController_` is re-seeded each time a fresh
+  // nnGenome arrives; the backend holds recurrent hidden state across
+  // ticks within a span, and reset() is called on span start (spec 027).
+  // std::unique_ptr so we can rebuild when the genome changes without
+  // needing a default-constructed NNControllerBackend.
   NNGenome nnGenome;
+  std::unique_ptr<NNControllerBackend> nnController_;
   std::vector<Path> path;
 };
 

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -50,7 +50,6 @@ using namespace std;
 #define EVAL_UPDATE_INTERVAL_MSEC_DEFAULT 100   // Sensor+NN cadence (~10Hz)
 #define COMPUTE_LATENCY_MSEC_DEFAULT 30         // Bench-measured: consolidated MSP fetch(12)+eval(5)+send(12)=29ms
 #define ENGAGE_DELAY_MSEC_DEFAULT 750           // Measured INAV MANUAL→autoc handoff delay (2026-04-07 flight)
-#define SIM_FPS 25.0                            // ~40 Hz physics tick assumption for overflow calc
 
 // ACRO mode rate PID — converts NN rate commands to surface deflections
 // NN output [-1,1] → desired rate [-max_rate, +max_rate] rad/s
@@ -93,7 +92,6 @@ using namespace std;
 // Settable at runtime (see inputdev_autoc.cpp).
 extern unsigned long gEvalUpdateIntervalMsec;
 extern unsigned long gComputeLatencyMsec;
-unsigned long getCycleCounterOverflow();
 
 class T_TX_InterfaceAUTOC : public T_TX_Interface
 {
@@ -128,6 +126,8 @@ private:
 
   unsigned long lastUpdateTimeMsec = 0;
   unsigned long cycleCounter = 0;
+  unsigned long framesPerEval = 0;   // set in init(); NN eval fires every framesPerEval-th outer frame
+  bool isHeadless = false;           // set in init() from video.enabled — diagnostic only (both modes use the same cadence path)
   bool simCrashed = false;
 
   gp_scalar pitchCommand = 0;

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -34,7 +34,6 @@
 #include "autoc/eval/sensor_math.h"
 #include "autoc/nn/nn_input_computation.h"
 #include "autoc/eval/variation_generator.h"
-#include "autoc/eval/acro_pid.h"
 #include "autoc/util/socket_wrapper.h"
 
 #include <stdio.h>
@@ -52,54 +51,15 @@ using namespace std;
 #define COMPUTE_LATENCY_MSEC_DEFAULT 30         // Bench-measured: consolidated MSP fetch(12)+eval(5)+send(12)=29ms
 #define ENGAGE_DELAY_MSEC_DEFAULT 750           // Measured INAV MANUAL→autoc handoff delay (2026-04-07 flight)
 
-// ACRO mode rate PID — converts NN rate commands to surface deflections
-// NN output [-1,1] → desired rate [-max_rate, +max_rate] rad/s
-// PID: error = desired_rate - actual_rate (rad/s) → surface deflection [-1,1]
-// All rate math in rad/s to match FDM and AircraftState convention.
-//
-// Max angular rates (deg/s config, converted to rad/s in PID code)
-// Set to match actual FDM rate capability at full surface deflection.
+// Max angular rates — used only to express NN rate-equivalent command in
+// `rateCmdP/Q` diagnostic columns (see PidInternals). Behaviorally the NN
+// output is a direct surface deflection in [-1,+1]; no PID in the loop.
 // Real aircraft (Mar 27 flight): roll ~430°/s, pitch ~300°/s.
-// These are NOT the INAV rate_param config values (560/400/240).
+// 026 attempted an external ACRO rate PID; it failed (fitness + bang-bang
+// got worse). See specs/026-nn-temporal-state/findings.md. 027 is pursuing
+// NN-internal memory instead.
 #define ACRO_MAX_RATE_ROLL  430.0               // flight measured max roll ≈ 7.50 rad/s
 #define ACRO_MAX_RATE_PITCH 300.0               // flight measured max pitch ≈ 5.24 rad/s
-#define ACRO_MAX_RATE_YAW   180.0               // estimated (no rudder, yaw from coupling)
-
-// PID gains — empirical for CRRCSim FDM (NOT direct copies of INAV gains)
-// INAV's gains are tuned for its own internal units and servo response.
-// These must be strong enough that at ZERO command, P+I can counter
-// aerodynamic coupling (sideslip→roll, etc.) to hold attitude.
-// Rule of thumb: P * max_disturbance_rate / SCALE should produce
-// enough surface deflection to counter the disturbance.
-// FF: feedforward (proportional to desired rate)
-// P:  proportional to rate error — must be large enough to hold attitude
-// I:  integral of rate error — drives steady-state error to zero
-#define ACRO_FF_ROLL   50.0
-#define ACRO_P_ROLL    40.0
-#define ACRO_I_ROLL    15.0
-#define ACRO_FF_PITCH  50.0
-#define ACRO_P_PITCH   40.0
-#define ACRO_I_PITCH   15.0
-#define ACRO_FF_YAW    60.0
-#define ACRO_P_YAW     40.0
-#define ACRO_I_YAW     15.0
-
-// PID output scaling — divides PID sum to produce [-1,1] surface deflection
-// At full roll (7.50 rad/s): FF*7.50/SCALE = 50*7.50/350 = 1.07 (clamped, full authority)
-// At full pitch (5.24 rad/s): FF*5.24/SCALE = 50*5.24/350 = 0.75 (good authority + P/I headroom)
-// Tune this to match FDM rate response. Too low = overshoot, too high = sluggish.
-#define ACRO_PID_SCALE 350.0
-
-// Inner-loop filter cutoffs — sim-cadence-derived (NOT copied from INAV's
-// 25/10 values). Sim runs ACRO PID at the outer-frame tick (20 Hz), so
-// cutoffs are placed at multiples of that rate:
-//   GYRO_LPF_HZ = 40 → 2× outer frame, 4× NN command rate (10 Hz), 1/5 FDM
-//   DTERM_LPF_HZ = 20 → outer-frame rate, dormant while D gain is 0
-// See specs/026-nn-temporal-state/research.md § "Sim PID implementation
-// notes" for derivation. Discrete α computed at filter init from:
-//   α = exp(-2π · fc · dt)
-#define ACRO_GYRO_LPF_HZ  40.0
-#define ACRO_DTERM_LPF_HZ 20.0
 
 // Settable at runtime (see inputdev_autoc.cpp).
 extern unsigned long gEvalUpdateIntervalMsec;

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -34,6 +34,7 @@
 #include "autoc/eval/sensor_math.h"
 #include "autoc/nn/nn_input_computation.h"
 #include "autoc/eval/variation_generator.h"
+#include "autoc/eval/acro_pid.h"
 #include "autoc/util/socket_wrapper.h"
 
 #include <stdio.h>
@@ -88,6 +89,17 @@ using namespace std;
 // At full pitch (5.24 rad/s): FF*5.24/SCALE = 50*5.24/350 = 0.75 (good authority + P/I headroom)
 // Tune this to match FDM rate response. Too low = overshoot, too high = sluggish.
 #define ACRO_PID_SCALE 350.0
+
+// Inner-loop filter cutoffs — sim-cadence-derived (NOT copied from INAV's
+// 25/10 values). Sim runs ACRO PID at the outer-frame tick (20 Hz), so
+// cutoffs are placed at multiples of that rate:
+//   GYRO_LPF_HZ = 40 → 2× outer frame, 4× NN command rate (10 Hz), 1/5 FDM
+//   DTERM_LPF_HZ = 20 → outer-frame rate, dormant while D gain is 0
+// See specs/026-nn-temporal-state/research.md § "Sim PID implementation
+// notes" for derivation. Discrete α computed at filter init from:
+//   α = exp(-2π · fc · dt)
+#define ACRO_GYRO_LPF_HZ  40.0
+#define ACRO_DTERM_LPF_HZ 20.0
 
 // Settable at runtime (see inputdev_autoc.cpp).
 extern unsigned long gEvalUpdateIntervalMsec;


### PR DESCRIPTION
## Summary

Submodule companion to https://github.com/gcmcnutt/autoc/pull/2.

- **027** — persistent `NNControllerBackend` instance on `T_TX_InterfaceAUTOC` (constructed once per span; `reset()` at span start; per-tick `evaluate()` on the member). Required for the recurrent forward pass on the autoc side to actually carry hidden state across NN ticks; works equally well in the diagnostic feedforward configuration that flew on 04-26.
- **027** — ACRO PID math nullified (unity passthrough, filter + integrator state stripped). The 13 `PidInternals` columns stay populated as observational diagnostics on the autoc side. See https://github.com/gcmcnutt/autoc/pull/2 for the closure narrative.
- **026** — ACRO PID port-back from 021 (later nullified above; included for history).
- **024** — WI4 cadence + frame-counter / startup integrality check (predates 027 but unmerged on this submodule).

## Test plan

- [ ] CRRCSim builds clean with the autoc-side 027 tree (autoc PR #2).
- [ ] Engagement smoke: span-start `nnController_.reset()` fires once per span; per-tick `nnController_.evaluate(...)` produces same outputs as the prior per-tick-construct pattern when `NN_RECURRENT[]` is all-false (cadence7-redux config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)