### PR TITLE
032 phase 1 T019 — mirror span computation in crrcsim tracker helper

### DIFF
--- a/src/mod_inputdev/CMakeLists.txt
+++ b/src/mod_inputdev/CMakeLists.txt
@@ -6,6 +6,8 @@ set(MOD_INPUTDEV_SRCS
   inputdev_mnav/mnav.cpp
   inputdev_autoc/inputdev_autoc.cpp
   inputdev_autoc/inputdev_autoc.h
+  inputdev_autoc/crrcsim_tracker_helper.cpp
+  inputdev_autoc/crrcsim_tracker_helper.h
   inputdev_PPM/inputdev_PPM.cpp
   inputdev_rctran/inputdev_rctran.cpp
   inputdev_rctran2/inputdev_rctran2.cpp

--- a/src/mod_inputdev/CMakeLists.txt
+++ b/src/mod_inputdev/CMakeLists.txt
@@ -18,11 +18,14 @@ set(MOD_INPUTDEV_SRCS
   inputdev_software/inputdev_software.cpp
   inputdev_zhenhua/inputdev_zhenhua.cpp
   inputdev_ct6a/inputdev_ct6a.cpp
-  ${CMAKE_SOURCE_DIR}/src/nn/evaluator.cc
-  ${CMAKE_SOURCE_DIR}/src/nn/serialization.cc
-  ${CMAKE_SOURCE_DIR}/src/eval/sensor_math.cc
  )
 add_library(mod_inputdev ${MOD_INPUTDEV_SRCS})
+
+# T003 (030 M1): link autoc_common rather than cherry-picking sources.
+# Restores Constitution IV (Unified Build): single source of truth for
+# autoc-side .cc files, no risk of new files in src/nn/ or src/eval/
+# silently breaking the crrcsim link (the 028 telemetry incident).
+target_link_libraries(mod_inputdev autoc_common)
 
 set (MOD_INPUTDEV_LIBS    )
 set (MOD_INPUTDEV_INCDIRS )

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -39,7 +39,7 @@ void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
 
     // CrashHull config from EvalData (autoc-side reads autoc-tracker.ini).
     crash_hull_ = CrashHull{};
-    crash_hull_.radius = evalData.crashHullRadius;
+    crash_hull_.sphere_radius_m = evalData.crashHullRadius;
 
     // PRNG seed = scenarioSequence with anti-zero guard. Park-Miller LCG
     // requires non-zero in [1, 2^31-2]. Identical guard logic as minisim's

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -42,11 +42,15 @@ void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
     crash_hull_ = CrashHull{};
     crash_hull_.sphere_radius_m = init.crashHullRadius;
 
-    // PRNG seed = scenarioSequence with anti-zero guard. Park-Miller LCG
-    // requires non-zero in [1, 2^31-2]. Identical guard logic as minisim's
-    // TrackerStepper ctor — same scenario gives same PRNG sequence across
-    // crrcsim/minisim (determinism contract).
-    const uint32_t seed = static_cast<uint32_t>(meta.scenarioSequence);
+    // PRNG seed = windSeed with anti-zero guard. Park-Miller LCG requires
+    // non-zero in [1, 2^31-2]. windSeed (NOT scenarioSequence) for
+    // determinism: scenarioSequence is a monotonic counter that differs
+    // between training-eval (seq=N) and elite-reeval (seq=N+~5000+) of the
+    // same scenario, which produced different LCG sequences → different
+    // didCrashFire Bernoulli draws → ELITE_DIVERGED warnings (2026-05-09).
+    // windSeed is per-scenario joint-PRNG-derived, stable across train/
+    // elite for the same scenario index. Same scenario → same hull-PRNG.
+    const uint32_t seed = static_cast<uint32_t>(meta.windSeed);
     prng_state_ = ((seed == 0 ? 0xC0FFEEu : seed % 0x7FFFFFFFu)) | 1u;
 
     // Reset NN recurrent state at scenario start (no-op for feedforward).
@@ -163,16 +167,19 @@ CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
         }
     }
 
-    // Step 5: crash hull strike (didCrashFire short-circuits when chase
-    // is outside hull — no PRNG draw consumed, scenario stream stays
-    // deterministic across hull-miss ticks). Arena egress wins on tie.
-    if (crash == CrashReason::None) {
-        if (didCrashFire(crash_hull_, chaseState.getPosition(), target.position,
-                         pCrashThisGen, prng_state_)) {
-            crash = CrashReason::HullStrike;
-            ++hull_fired_count_;
-        }
-    }
+    // 030 V1.5 (2026-05-09) — Crash-hull DISABLED in code while we sort
+    // determinism back out. Skipping the didCrashFire call entirely so it
+    // can't consume from the per-scenario PRNG stream regardless of
+    // pCrashThisGen / hull radius config. Mirrors the same disable in
+    // src/eval/tracker_stepper.cc — re-enable both at once when ready.
+    //
+    // if (crash == CrashReason::None) {
+    //     if (didCrashFire(crash_hull_, chaseState.getPosition(), target.position,
+    //                      pCrashThisGen, prng_state_)) {
+    //         crash = CrashReason::HullStrike;
+    //         ++hull_fired_count_;
+    //     }
+    // }
 
     ++cursor_;
     return crash;

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -167,19 +167,17 @@ CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
         }
     }
 
-    // 030 V1.5 (2026-05-09) — Crash-hull DISABLED in code while we sort
-    // determinism back out. Skipping the didCrashFire call entirely so it
-    // can't consume from the per-scenario PRNG stream regardless of
-    // pCrashThisGen / hull radius config. Mirrors the same disable in
-    // src/eval/tracker_stepper.cc — re-enable both at once when ready.
-    //
-    // if (crash == CrashReason::None) {
-    //     if (didCrashFire(crash_hull_, chaseState.getPosition(), target.position,
-    //                      pCrashThisGen, prng_state_)) {
-    //         crash = CrashReason::HullStrike;
-    //         ++hull_fired_count_;
-    //     }
-    // }
+    // 030 M11.preA.3 (2026-05-10) — Crash-hull RE-ENABLED with fixed
+    // Bernoulli probability per NN tick (10Hz). Seed = windSeed (P1 fix,
+    // stable train↔elite). Mirrors the parallel re-enable in
+    // src/eval/tracker_stepper.cc — keep both bodies in lockstep.
+    if (crash == CrashReason::None) {
+        if (didCrashFire(crash_hull_, chaseState.getPosition(), target.position,
+                         pCrashThisGen, prng_state_)) {
+            crash = CrashReason::HullStrike;
+            ++hull_fired_count_;
+        }
+    }
 
     ++cursor_;
     return crash;

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -30,16 +30,17 @@ using autoc::eval::BeaconObservation;
 
 void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
                                         const ScenarioMetadata& meta,
-                                        const EvalData& evalData,
+                                        const WorkerInit& init,
                                         AircraftState& chaseState,
                                         NNControllerBackend& nn) {
     source_ = &source;
     cursor_ = 0;
     hull_fired_count_ = 0;
 
-    // CrashHull config from EvalData (autoc-side reads autoc-tracker.ini).
+    // 030 V1 priming — CrashHull config from WorkerInit (autoc-side reads
+    // autoc-tracker.ini and ships once per worker, not per eval).
     crash_hull_ = CrashHull{};
-    crash_hull_.sphere_radius_m = evalData.crashHullRadius;
+    crash_hull_.sphere_radius_m = init.crashHullRadius;
 
     // PRNG seed = scenarioSequence with anti-zero guard. Park-Miller LCG
     // requires non-zero in [1, 2^31-2]. Identical guard logic as minisim's
@@ -57,7 +58,7 @@ void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
     if (!source_->samples.empty()) {
         const SourceTickSample& first = source_->samples.front();
         for (int i = 0; i < 6; ++i) {
-            projectAndShiftHistory(first, chaseState, evalData);
+            projectAndShiftHistory(first, chaseState, init);
         }
     }
     // Cursor stays at 0 — first tick() consumes source[0] (the same sample
@@ -66,7 +67,7 @@ void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
 
 void CrrcsimTrackerHelper::projectAndShiftHistory(const SourceTickSample& target,
                                                   const AircraftState& chaseState,
-                                                  const EvalData& evalData) {
+                                                  const WorkerInit& init) {
     // Shift slots [1..5] → [0..4]; new "now" lands at index 5.
     for (int i = 0; i < 5; ++i) {
         history_.left_x[i] = history_.left_x[i + 1];      // raw-ok: NN-byte-format primitive
@@ -77,28 +78,28 @@ void CrrcsimTrackerHelper::projectAndShiftHistory(const SourceTickSample& target
         history_.right_cep[i] = history_.right_cep[i + 1];// raw-ok: NN-byte-format primitive
     }
 
-    // Build projection inputs. Cameras + beacons all come from EvalData
-    // (autoc-side parses autoc-tracker.ini and ships these per job).
+    // 030 V1 priming — cameras + beacons + airframe come from WorkerInit
+    // (sent once per worker; autoc-side parses autoc-tracker.ini at startup).
     ProjectionInput proj;
     proj.chase_position_world = chaseState.getPosition();
     proj.chase_orientation_world = chaseState.getOrientation();
     proj.target_position_world = target.position;
     proj.target_orientation_world = target.orientation;
-    proj.camera_mount_chase_body = evalData.cameraConfig.mount_offset_body;
-    proj.camera_orientation_chase_body = evalData.cameraConfig.mount_orientation_body;
-    proj.camera = evalData.cameraConfig;
-    proj.chase_airframe = evalData.airframeProxy;
+    proj.camera_mount_chase_body = init.cameraConfig.mount_offset_body;
+    proj.camera_orientation_chase_body = init.cameraConfig.mount_orientation_body;
+    proj.camera = init.cameraConfig;
+    proj.chase_airframe = init.airframeProxy;
 
     // Left beacon.
-    proj.beacon_mount_target_body = evalData.beaconLeftConfig.mount_body;
-    proj.beacon_emission_axis_target_body = evalData.beaconLeftConfig.emission_axis_body;
-    proj.beacon = evalData.beaconLeftConfig;
+    proj.beacon_mount_target_body = init.beaconLeftConfig.mount_body;
+    proj.beacon_emission_axis_target_body = init.beaconLeftConfig.emission_axis_body;
+    proj.beacon = init.beaconLeftConfig;
     BeaconObservation left = projectBeacon(proj);
 
     // Right beacon.
-    proj.beacon_mount_target_body = evalData.beaconRightConfig.mount_body;
-    proj.beacon_emission_axis_target_body = evalData.beaconRightConfig.emission_axis_body;
-    proj.beacon = evalData.beaconRightConfig;
+    proj.beacon_mount_target_body = init.beaconRightConfig.mount_body;
+    proj.beacon_emission_axis_target_body = init.beaconRightConfig.emission_axis_body;
+    proj.beacon = init.beaconRightConfig;
     BeaconObservation right = projectBeacon(proj);
 
     history_.left_x[5] = left.screen_x;       // raw-ok: NN-byte-format primitive
@@ -111,13 +112,13 @@ void CrrcsimTrackerHelper::projectAndShiftHistory(const SourceTickSample& target
     // M2 dmp recording — mirror minisim's M8b populate.
     last_camera_view_.camera_pose_world_pos =
         chaseState.getPosition() + chaseState.getOrientation() *
-        evalData.cameraConfig.mount_offset_body;
+        init.cameraConfig.mount_offset_body;
     last_camera_view_.camera_pose_world_orient =
-        chaseState.getOrientation() * evalData.cameraConfig.mount_orientation_body;
+        chaseState.getOrientation() * init.cameraConfig.mount_orientation_body;
     last_camera_view_.camera_fov_h_deg =
-        static_cast<float>(evalData.cameraConfig.fov_h_deg);   // raw-ok: cereal byte-format member
+        static_cast<float>(init.cameraConfig.fov_h_deg);   // raw-ok: cereal byte-format member
     last_camera_view_.camera_fov_v_deg =
-        static_cast<float>(evalData.cameraConfig.fov_v_deg);   // raw-ok: cereal byte-format member
+        static_cast<float>(init.cameraConfig.fov_v_deg);   // raw-ok: cereal byte-format member
     last_camera_view_.beacon_left = left;
     last_camera_view_.beacon_right = right;
 
@@ -125,14 +126,15 @@ void CrrcsimTrackerHelper::projectAndShiftHistory(const SourceTickSample& target
     last_target_sample_.orientation = target.orientation;
     last_target_sample_.velocity = target.velocity;
     last_target_sample_.trail_rabbit_position =
-        computeTrailRabbit(target, evalData.trailDistance);
+        computeTrailRabbit(target, init.trailDistance);
     last_target_sample_.inside_crash_hull =
         isInsideHull(crash_hull_, chaseState.getPosition(), target.position);
 }
 
 CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
                                        NNControllerBackend& nn,
-                                       const EvalData& evalData) {
+                                       const WorkerInit& init,
+                                       gp_scalar pCrashThisGen) {
     if (source_ == nullptr || cursor_ >= source_->samples.size()) {
         return CrashReason::TimeLimit;
     }
@@ -142,11 +144,11 @@ CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
 
     // Step 1: project beacons + shift history (also populates last_camera_view_
     // + last_target_sample_ for M2 dmp recording).
-    projectAndShiftHistory(target, chaseState, evalData);
+    projectAndShiftHistory(target, chaseState, init);
 
     // Step 2: gather tracker NN inputs.
     TrackerInputs inputs = {};
-    gather_tracker_inputs(chaseState, history_, evalData.flightArena, inputs);
+    gather_tracker_inputs(chaseState, history_, init.flightArena, inputs);
 
     // Step 3: NN forward pass → updates chaseState.pitch/roll/throttle commands
     // (which inputdev_autoc.cpp's pending-command stage picks up post-tick).
@@ -155,7 +157,7 @@ CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
     // Step 4: arena out-of-bounds via FR-016 FlightArena (same source-of-truth
     // as gather_tracker_inputs slot 44).
     {
-        const ArenaEgressKind egress = checkArenaBounds(chaseState, evalData.flightArena);
+        const ArenaEgressKind egress = checkArenaBounds(chaseState, init.flightArena);
         if (egress != ArenaEgressKind::NONE) {
             crash = arenaEgressToCrashReason(egress);
         }
@@ -166,7 +168,7 @@ CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
     // deterministic across hull-miss ticks). Arena egress wins on tie.
     if (crash == CrashReason::None) {
         if (didCrashFire(crash_hull_, chaseState.getPosition(), target.position,
-                         evalData.pCrashThisGen, prng_state_)) {
+                         pCrashThisGen, prng_state_)) {
             crash = CrashReason::HullStrike;
             ++hull_fired_count_;
         }

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -1,0 +1,177 @@
+// 030 M11.preA — CRRCSim tracker-mode helper class implementation.
+//
+// Body intentionally mirrors minisim's TrackerStepper (src/eval/tracker_stepper.cc)
+// at the per-tick logic level. Adapted for crrcsim:
+//   - No state_ owned by helper — chase state lives in inputdev_autoc.cpp's
+//     `aircraftState` global, populated from FDM each NN tick. Helper takes
+//     it by reference each call.
+//   - No physics advance in tick() — crrcsim FDM advances on its own schedule;
+//     helper just reads chaseState (post-FDM-step) and writes NN commands
+//     back to it.
+//   - Cursor starts at 0 (no pre-roll) per M11.preA "match M1 init" decision.
+
+#include "crrcsim_tracker_helper.h"
+
+#include <algorithm>
+
+#include "autoc/eval/arena.h"
+#include "autoc/eval/trail_rabbit.h"
+
+using autoc::eval::CrashHull;
+using autoc::eval::ArenaEgressKind;
+using autoc::eval::checkArenaBounds;
+using autoc::eval::arenaEgressToCrashReason;
+using autoc::eval::projectBeacon;
+using autoc::eval::computeTrailRabbit;
+using autoc::eval::isInsideHull;
+using autoc::eval::didCrashFire;
+using autoc::eval::ProjectionInput;
+using autoc::eval::BeaconObservation;
+
+void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
+                                        const ScenarioMetadata& meta,
+                                        const EvalData& evalData,
+                                        AircraftState& chaseState,
+                                        NNControllerBackend& nn) {
+    source_ = &source;
+    cursor_ = 0;
+    hull_fired_count_ = 0;
+
+    // CrashHull config from EvalData (autoc-side reads autoc-tracker.ini).
+    crash_hull_ = CrashHull{};
+    crash_hull_.radius = evalData.crashHullRadius;
+
+    // PRNG seed = scenarioSequence with anti-zero guard. Park-Miller LCG
+    // requires non-zero in [1, 2^31-2]. Identical guard logic as minisim's
+    // TrackerStepper ctor — same scenario gives same PRNG sequence across
+    // crrcsim/minisim (determinism contract).
+    const uint32_t seed = static_cast<uint32_t>(meta.scenarioSequence);
+    prng_state_ = ((seed == 0 ? 0xC0FFEEu : seed % 0x7FFFFFFFu)) | 1u;
+
+    // Reset NN recurrent state at scenario start (no-op for feedforward).
+    nn.reset();
+
+    // Pre-fill history with source[0] projection replicated 6×, so the NN
+    // sees a coherent stationary-source history at first tick. Mirrors the
+    // M9.preB minisim TrackerStepper init for the pre_roll == 0 case.
+    if (!source_->samples.empty()) {
+        const SourceTickSample& first = source_->samples.front();
+        for (int i = 0; i < 6; ++i) {
+            projectAndShiftHistory(first, chaseState, evalData);
+        }
+    }
+    // Cursor stays at 0 — first tick() consumes source[0] (the same sample
+    // we just used to pre-fill history; that's fine, history shifts cleanly).
+}
+
+void CrrcsimTrackerHelper::projectAndShiftHistory(const SourceTickSample& target,
+                                                  const AircraftState& chaseState,
+                                                  const EvalData& evalData) {
+    // Shift slots [1..5] → [0..4]; new "now" lands at index 5.
+    for (int i = 0; i < 5; ++i) {
+        history_.left_x[i] = history_.left_x[i + 1];      // raw-ok: NN-byte-format primitive
+        history_.left_y[i] = history_.left_y[i + 1];      // raw-ok: NN-byte-format primitive
+        history_.left_cep[i] = history_.left_cep[i + 1];  // raw-ok: NN-byte-format primitive
+        history_.right_x[i] = history_.right_x[i + 1];    // raw-ok: NN-byte-format primitive
+        history_.right_y[i] = history_.right_y[i + 1];    // raw-ok: NN-byte-format primitive
+        history_.right_cep[i] = history_.right_cep[i + 1];// raw-ok: NN-byte-format primitive
+    }
+
+    // Build projection inputs. Cameras + beacons all come from EvalData
+    // (autoc-side parses autoc-tracker.ini and ships these per job).
+    ProjectionInput proj;
+    proj.chase_position_world = chaseState.getPosition();
+    proj.chase_orientation_world = chaseState.getOrientation();
+    proj.target_position_world = target.position;
+    proj.target_orientation_world = target.orientation;
+    proj.camera_mount_chase_body = evalData.cameraConfig.mount_offset_body;
+    proj.camera_orientation_chase_body = evalData.cameraConfig.mount_orientation_body;
+    proj.camera = evalData.cameraConfig;
+    proj.chase_airframe = evalData.airframeProxy;
+
+    // Left beacon.
+    proj.beacon_mount_target_body = evalData.beaconLeftConfig.mount_body;
+    proj.beacon_emission_axis_target_body = evalData.beaconLeftConfig.emission_axis_body;
+    proj.beacon = evalData.beaconLeftConfig;
+    BeaconObservation left = projectBeacon(proj);
+
+    // Right beacon.
+    proj.beacon_mount_target_body = evalData.beaconRightConfig.mount_body;
+    proj.beacon_emission_axis_target_body = evalData.beaconRightConfig.emission_axis_body;
+    proj.beacon = evalData.beaconRightConfig;
+    BeaconObservation right = projectBeacon(proj);
+
+    history_.left_x[5] = left.screen_x;       // raw-ok: NN-byte-format primitive
+    history_.left_y[5] = left.screen_y;       // raw-ok: NN-byte-format primitive
+    history_.left_cep[5] = left.cep;          // raw-ok: NN-byte-format primitive
+    history_.right_x[5] = right.screen_x;     // raw-ok: NN-byte-format primitive
+    history_.right_y[5] = right.screen_y;     // raw-ok: NN-byte-format primitive
+    history_.right_cep[5] = right.cep;        // raw-ok: NN-byte-format primitive
+
+    // M2 dmp recording — mirror minisim's M8b populate.
+    last_camera_view_.camera_pose_world_pos =
+        chaseState.getPosition() + chaseState.getOrientation() *
+        evalData.cameraConfig.mount_offset_body;
+    last_camera_view_.camera_pose_world_orient =
+        chaseState.getOrientation() * evalData.cameraConfig.mount_orientation_body;
+    last_camera_view_.camera_fov_h_deg =
+        static_cast<float>(evalData.cameraConfig.fov_h_deg);   // raw-ok: cereal byte-format member
+    last_camera_view_.camera_fov_v_deg =
+        static_cast<float>(evalData.cameraConfig.fov_v_deg);   // raw-ok: cereal byte-format member
+    last_camera_view_.beacon_left = left;
+    last_camera_view_.beacon_right = right;
+
+    last_target_sample_.position = target.position;
+    last_target_sample_.orientation = target.orientation;
+    last_target_sample_.velocity = target.velocity;
+    last_target_sample_.trail_rabbit_position =
+        computeTrailRabbit(target, evalData.trailDistance);
+    last_target_sample_.inside_crash_hull =
+        isInsideHull(crash_hull_, chaseState.getPosition(), target.position);
+}
+
+CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
+                                       NNControllerBackend& nn,
+                                       const EvalData& evalData) {
+    if (source_ == nullptr || cursor_ >= source_->samples.size()) {
+        return CrashReason::TimeLimit;
+    }
+
+    CrashReason crash = CrashReason::None;
+    const SourceTickSample& target = source_->samples[cursor_];
+
+    // Step 1: project beacons + shift history (also populates last_camera_view_
+    // + last_target_sample_ for M2 dmp recording).
+    projectAndShiftHistory(target, chaseState, evalData);
+
+    // Step 2: gather tracker NN inputs.
+    TrackerInputs inputs = {};
+    gather_tracker_inputs(chaseState, history_, evalData.flightArena, inputs);
+
+    // Step 3: NN forward pass → updates chaseState.pitch/roll/throttle commands
+    // (which inputdev_autoc.cpp's pending-command stage picks up post-tick).
+    nn.evaluateTracker(chaseState, inputs);
+
+    // Step 4: arena out-of-bounds via FR-016 FlightArena (same source-of-truth
+    // as gather_tracker_inputs slot 44).
+    {
+        const ArenaEgressKind egress = checkArenaBounds(chaseState, evalData.flightArena);
+        if (egress != ArenaEgressKind::NONE) {
+            crash = arenaEgressToCrashReason(egress);
+        }
+    }
+
+    // Step 5: crash hull strike (didCrashFire short-circuits when chase
+    // is outside hull — no PRNG draw consumed, scenario stream stays
+    // deterministic across hull-miss ticks). Arena egress wins on tie.
+    if (crash == CrashReason::None) {
+        if (didCrashFire(crash_hull_, chaseState.getPosition(), target.position,
+                         evalData.pCrashThisGen, prng_state_)) {
+            crash = CrashReason::HullStrike;
+            ++hull_fired_count_;
+        }
+    }
+
+    ++cursor_;
+    return crash;
+}

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 
 #include "autoc/eval/arena.h"
+#include "autoc/eval/derived_features.h"  // 032 phase 1 — compute_pair_span
 #include "autoc/eval/trail_rabbit.h"
 
 using autoc::eval::CrashHull;
@@ -80,6 +81,7 @@ void CrrcsimTrackerHelper::projectAndShiftHistory(const SourceTickSample& target
         history_.right_x[i] = history_.right_x[i + 1];    // raw-ok: NN-byte-format primitive
         history_.right_y[i] = history_.right_y[i + 1];    // raw-ok: NN-byte-format primitive
         history_.right_cep[i] = history_.right_cep[i + 1];// raw-ok: NN-byte-format primitive
+        history_.span[i] = history_.span[i + 1];          // raw-ok: NN-byte-format primitive — 032 phase 1
     }
 
     // 030 V1 priming — cameras + beacons + airframe come from WorkerInit
@@ -112,6 +114,26 @@ void CrrcsimTrackerHelper::projectAndShiftHistory(const SourceTickSample& target
     history_.right_x[5] = right.screen_x;     // raw-ok: NN-byte-format primitive
     history_.right_y[5] = right.screen_y;     // raw-ok: NN-byte-format primitive
     history_.right_cep[5] = right.cep;        // raw-ok: NN-byte-format primitive
+
+    // 032 PHASE 1 — Cache beacon-pair span at the current tick. CEP-gated:
+    // if EITHER beacon's CEP exceeds the configured threshold, substitute
+    // neutral 0.0. Mirrors src/eval/tracker_stepper.cc::projectAndShiftHistory
+    // exactly. cep_gate_threshold comes from init.cepGateThreshold (no
+    // ConfigManager on the crrcsim worker — value threaded via WorkerInit).
+    const float cep_gate_threshold = static_cast<float>(init.cepGateThreshold);
+    const bool cep_gated =
+        left.cep >= cep_gate_threshold ||
+        right.cep >= cep_gate_threshold;
+    if (cep_gated) {
+        history_.span[5] = 0.0f;
+    } else {
+        history_.span[5] = static_cast<float>(  // raw-ok: NN-byte-format slot write
+            autoc::eval::compute_pair_span(
+                static_cast<gp_scalar>(left.screen_x),
+                static_cast<gp_scalar>(left.screen_y),
+                static_cast<gp_scalar>(right.screen_x),
+                static_cast<gp_scalar>(right.screen_y)));
+    }
 
     // M2 dmp recording — mirror minisim's M8b populate.
     last_camera_view_.camera_pose_world_pos =

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
@@ -1,0 +1,92 @@
+// 030 M11.preA — CRRCSim tracker-mode helper class.
+//
+// Mirror of minisim's TrackerStepper at the per-tick logic level, adapted
+// for crrcsim's mod_inputdev calling convention. Encapsulates the source-
+// trajectory cursor, beacon history window, crash hull state, beacon
+// projection per tick, gather_tracker_inputs, and evaluateTracker NN forward.
+//
+// Design choices (per specs/030-tracker-mode/m11_prea_plan.md):
+// - Helper class, NOT a strategy interface — keeps pathgen body in
+//   inputdev_autoc.cpp strictly untouched (regression-tight bitwise gate)
+// - Chase init NOT shifted by trail_distance (unlike minisim M9.preB) —
+//   crrcsim FDM defaults hb1 to ~13 m/s cruise, no need to defeat the
+//   minisim 20-m/s init spike
+// - All per-tick primitives reused from autoc_common: projectBeacon,
+//   gather_tracker_inputs, computeTrailRabbit (via the tick body),
+//   CrashHull, FlightArena
+// - Determinism: zero wall-clock / thread-id state. PRNG seeded from
+//   scenarioMetadata.scenarioSequence (already deterministic in autoc).
+
+#pragma once
+
+#include <cstdint>
+
+#include "autoc/eval/aircraft_state.h"
+#include "autoc/eval/beacon_config.h"
+#include "autoc/eval/camera_config.h"
+#include "autoc/eval/camera_projection.h"
+#include "autoc/eval/crash_hull.h"
+#include "autoc/eval/source_trajectory.h"
+#include "autoc/nn/evaluator.h"
+#include "autoc/rpc/protocol.h"
+
+class CrrcsimTrackerHelper {
+public:
+    // Called at scenario boundary (analogous to TrackerStepper::initScenario):
+    // - Cursor = 0
+    // - PRNG seeded from scenarioMetadata.scenarioSequence (with anti-zero guard)
+    // - Crash hull initialized from EvalData
+    // - History window pre-filled with source[0] projection replicated 6× so
+    //   the NN sees a coherent stationary-source history at first tick
+    //
+    // chaseState is FDM-initialized by the caller before this is called
+    // (the M1-style scenario reset path in inputdev_autoc.cpp populates
+    // initial chase pose from the FDM post-reset state).
+    void initScenario(const SourceScenarioTrajectory& source,
+                      const ScenarioMetadata& meta,
+                      const EvalData& evalData,
+                      AircraftState& chaseState,
+                      NNControllerBackend& nn);
+
+    // Per-NN-tick body. chaseState is post-FDM-step (caller has just
+    // updated it from FDM). Returns:
+    //   - CrashReason::HullStrike if didCrashFire fires this tick
+    //   - CrashReason::Eval if checkArenaBounds reports egress
+    //   - CrashReason::None otherwise (caller adds time-limit / source-end
+    //     checks separately, matching minisim TrackerStepper convention)
+    //
+    // Side effects:
+    //   - cursor_ advances
+    //   - history_ shifts left + slot 5 = new beacon projection
+    //   - last_camera_view_ + last_target_sample_ populated for M2 dmp
+    //   - chaseState.pitchCommand/rollCommand/throttleCommand updated by NN
+    CrashReason tick(AircraftState& chaseState,
+                     NNControllerBackend& nn,
+                     const EvalData& evalData);
+
+    // For M2 dmp recording — caller pushes these into
+    // evalResults.cameraViewList[scenario] / targetTrajectoryList[scenario]
+    // per tick, parallel to aircraftStateList push.
+    const CameraViewSample& lastCameraView() const { return last_camera_view_; }
+    const CopiedTargetSample& lastTargetSample() const { return last_target_sample_; }
+    int hullFiredCount() const { return hull_fired_count_; }
+    bool sourceExhausted() const { return source_ == nullptr || cursor_ >= source_->samples.size(); }
+
+private:
+    // Project both wingtip beacons against the current target sample,
+    // shift history left, write slot 5. Also populates last_camera_view_ +
+    // last_target_sample_ for M2 dmp output.
+    void projectAndShiftHistory(const SourceTickSample& target,
+                                const AircraftState& chaseState,
+                                const EvalData& evalData);
+
+    size_t cursor_ = 0;
+    TrackerHistoryWindow history_{};
+    autoc::eval::CrashHull crash_hull_{};
+    uint32_t prng_state_ = 0;
+    int hull_fired_count_ = 0;
+    CameraViewSample last_camera_view_{};
+    CopiedTargetSample last_target_sample_{};
+    // Reference to source samples — set in initScenario. NOT owned.
+    const SourceScenarioTrajectory* source_ = nullptr;
+};

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
@@ -15,7 +15,10 @@
 //   gather_tracker_inputs, computeTrailRabbit (via the tick body),
 //   CrashHull, FlightArena
 // - Determinism: zero wall-clock / thread-id state. PRNG seeded from
-//   scenarioMetadata.scenarioSequence (already deterministic in autoc).
+//   scenarioMetadata.windSeed (joint-PRNG-derived, stable across
+//   training-eval and elite-reeval of the same scenario index — was
+//   scenarioSequence pre-2026-05-09 but that drifted seed values
+//   between train/elite calls, producing ELITE_DIVERGED warnings).
 
 #pragma once
 
@@ -34,7 +37,8 @@ class CrrcsimTrackerHelper {
 public:
     // Called at scenario boundary (analogous to TrackerStepper::initScenario):
     // - Cursor = 0
-    // - PRNG seeded from scenarioMetadata.scenarioSequence (with anti-zero guard)
+    // - PRNG seeded from scenarioMetadata.windSeed (with anti-zero guard;
+    //   was scenarioSequence pre-2026-05-09 — see TU comment above)
     // - Crash hull initialized from WorkerInit (030 V1 priming —
     //   crashHullRadius lives on the once-per-worker WorkerInit, not in
     //   per-eval EvalData).

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
@@ -35,7 +35,9 @@ public:
     // Called at scenario boundary (analogous to TrackerStepper::initScenario):
     // - Cursor = 0
     // - PRNG seeded from scenarioMetadata.scenarioSequence (with anti-zero guard)
-    // - Crash hull initialized from EvalData
+    // - Crash hull initialized from WorkerInit (030 V1 priming —
+    //   crashHullRadius lives on the once-per-worker WorkerInit, not in
+    //   per-eval EvalData).
     // - History window pre-filled with source[0] projection replicated 6× so
     //   the NN sees a coherent stationary-source history at first tick
     //
@@ -44,7 +46,7 @@ public:
     // initial chase pose from the FDM post-reset state).
     void initScenario(const SourceScenarioTrajectory& source,
                       const ScenarioMetadata& meta,
-                      const EvalData& evalData,
+                      const WorkerInit& init,
                       AircraftState& chaseState,
                       NNControllerBackend& nn);
 
@@ -55,6 +57,11 @@ public:
     //   - CrashReason::None otherwise (caller adds time-limit / source-end
     //     checks separately, matching minisim TrackerStepper convention)
     //
+    // 030 V1 priming — `init` carries scenario-static configs (camera,
+    // beacons, airframe proxy, flight arena, trail distance). `pCrashThisGen`
+    // ramps per-gen so it stays separate (pulled from the per-eval EvalData
+    // by the caller).
+    //
     // Side effects:
     //   - cursor_ advances
     //   - history_ shifts left + slot 5 = new beacon projection
@@ -62,7 +69,8 @@ public:
     //   - chaseState.pitchCommand/rollCommand/throttleCommand updated by NN
     CrashReason tick(AircraftState& chaseState,
                      NNControllerBackend& nn,
-                     const EvalData& evalData);
+                     const WorkerInit& init,
+                     gp_scalar pCrashThisGen);
 
     // For M2 dmp recording — caller pushes these into
     // evalResults.cameraViewList[scenario] / targetTrajectoryList[scenario]
@@ -78,7 +86,7 @@ private:
     // last_target_sample_ for M2 dmp output.
     void projectAndShiftHistory(const SourceTickSample& target,
                                 const AircraftState& chaseState,
-                                const EvalData& evalData);
+                                const WorkerInit& init);
 
     size_t cursor_ = 0;
     TrackerHistoryWindow history_{};

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -29,6 +29,7 @@
 #include "../../mod_misc/crrc_rand.h"
 #include "../../mod_windfield/windfield.h"
 #include "inputdev_autoc.h"
+#include "autoc/eval/scenario_meta_apply.h"  // 030 V1.5 — applyVariationScale
 #include "autoc/eval/variation_generator.h"
 #include <algorithm>
 #include <chrono>
@@ -61,26 +62,26 @@ unsigned long parseIntervalFromEnv(const char* name, unsigned long fallback) {
   return val;
 }
 
-void ensureScenarioMetadata(EvalData& evalData) {
-  if (evalData.scenarioList.size() == evalData.pathList.size()) {
-    return;
-  }
-  evalData.scenarioList.assign(evalData.pathList.size(), evalData.scenario);
-  for (size_t idx = 0; idx < evalData.scenarioList.size(); ++idx) {
-    if (evalData.scenarioList[idx].pathVariantIndex < 0) {
-      evalData.scenarioList[idx].pathVariantIndex = static_cast<int>(idx);
-    }
-  }
-}
-
-ScenarioMetadata scenarioForPathIndex(const EvalData& evalData, size_t idx) {
-  if (idx < evalData.scenarioList.size()) {
-    return evalData.scenarioList.at(idx);
-  }
-  ScenarioMetadata meta = evalData.scenario;
-  if (meta.pathVariantIndex < 0) {
+// 030 V1.5 (2026-05-08) — build the per-eval ScenarioMetadata for
+// scenario index idx by copying the cached base meta from
+// init.scenarioMetaList[idx], overriding the per-eval fields
+// (scenarioSequence, enableDeterministicLogging) from EvalData, then
+// applying per-eval variation_scale. Mirrors minisim's makePerEvalMeta;
+// byte-equivalent to the legacy autoc-side populateVariationOffsets path
+// so the determinism contract is preserved.
+ScenarioMetadata makePerEvalMeta(const WorkerInit& init,
+                                 const EvalData& evalData,
+                                 size_t idx) {
+  ScenarioMetadata meta;
+  if (idx < init.scenarioMetaList.size()) {
+    meta = init.scenarioMetaList[idx];
+  } else {
     meta.pathVariantIndex = static_cast<int>(idx);
   }
+  meta.scenarioSequence = evalData.scenarioSequence;
+  meta.bakeoffSequence = 0;
+  meta.enableDeterministicLogging = evalData.isEliteReeval;
+  autoc::eval::applyVariationScale(meta, evalData.variationScale);
   return meta;
 }
 
@@ -334,6 +335,16 @@ int T_TX_InterfaceAUTOC::init(SimpleXMLTransfer *config)
 
   socket_ = new TcpSocket();
   socket_->connect("127.0.0.1", cfg->callback_port);
+
+  // 030 V1 priming (2026-05-08) — phone home is the TCP connect above;
+  // autoc's ThreadPool sends the once-per-worker WorkerInit immediately
+  // after its accept(). Cache locally for all subsequent eval ticks.
+  // Loud-fail if priming RPC fails — no fallback. Mirrors minisim's
+  // SimProcess ctor priming receive (tools/minisim.cc).
+  init_ = receiveRPC<WorkerInit>(*socket_);
+  std::cerr << "[AUTOC] crrcsim worker primed mode=" << modeToString(init_.mode)
+            << " sourceList=" << init_.sourceList.size() << " scenarios"
+            << std::endl;
   return (0);
 }
 
@@ -417,11 +428,12 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       if (evalData.gpHash == 0) {
         evalData.gpHash = localGpHash;
       }
-      ensureScenarioMetadata(evalData);
 
-      // Set flag for RNG tracing when entering deterministic test
-      gInDeterministicTest = (!evalData.scenarioList.empty() &&
-                              evalData.scenarioList.front().enableDeterministicLogging);
+      // 030 V1.5 — scenario library is worker-resident in init_; per-eval
+      // EvalData no longer carries pathList / scenarioList. Use cached
+      // pathList from priming and reconstruct per-eval metas via
+      // makePerEvalMeta(init_, evalData, idx).
+      gInDeterministicTest = evalData.isEliteReeval;
 
       evalDataEmpty = false;
       priorPathSelector = -1;
@@ -432,20 +444,17 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
 
       // Paths stay at canonical origin (Z=0). Aircraft position stored as virtual
       // (raw - pathOriginOffset). Origin offset captured at FDM reset per path.
-      evalResults.pathList = evalData.pathList;
+      evalResults.pathList = init_.pathList;  // 030 V1.5 — copy from cached library
       path = evalResults.pathList.at(pathSelector);
       evalResults.gp = evalData.gp;
       evalResults.gpHash = evalData.gpHash;
       if (evalResults.gpHash == 0 && !evalResults.gp.empty()) {
         evalResults.gpHash = hashByteVector(evalResults.gp);
       }
-      if (!evalData.scenarioList.empty()) {
-        evalResults.scenario = evalData.scenarioList.front();
-      } else {
-        evalResults.scenario = evalData.scenario;
-      }
+      // First per-eval meta (scenario 0) for the EvalResults summary slot.
+      evalResults.scenario = makePerEvalMeta(init_, evalData, 0);
       evalResults.scenarioList.clear();
-      evalResults.scenarioList.reserve(evalData.scenarioList.size());
+      evalResults.scenarioList.reserve(init_.pathList.size());
       evalResults.debugSamples.clear();
       evalResults.physicsTrace.clear();
       evalResults.workerId = workerIndex;
@@ -453,8 +462,8 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       evalResults.workerEvalCounter = evalCounter;
 
 #ifdef DETAILED_LOGGING
-      if (!evalData.scenarioList.empty()) {
-        const auto& firstScenario = evalData.scenarioList.front();
+      {
+        const auto& firstScenario = evalResults.scenario;
         std::cerr << "AUTOC deterministic wind seed=" << firstScenario.windSeed
                   << " pathVariant=" << firstScenario.pathVariantIndex
                   << " windVariant=" << firstScenario.windVariantIndex << std::endl;
@@ -484,7 +493,7 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
     if (priorPathSelector != pathSelector)
     {
       priorPathSelector = pathSelector;
-      ScenarioMetadata activeScenario = scenarioForPathIndex(evalData, static_cast<size_t>(pathSelector));
+      ScenarioMetadata activeScenario = makePerEvalMeta(init_, evalData, static_cast<size_t>(pathSelector));
 
       // VARIATIONS1: Set entry and wind variation offsets from scenario
       // These are read by initialize_flight_model() and windfield during reset
@@ -529,7 +538,7 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       // rabbit, NN commands fire from tick 0). 2026-05-08 fix: previously
       // generateSpeedProfile ran unconditionally and the result was
       // discarded in tracker mode — wasted CPU + memory. Moved into else.
-      const bool trackerModeActive = (evalData.mode == Mode::TRACKER);
+      const bool trackerModeActive = (init_.mode == Mode::TRACKER);
       if (trackerModeActive) {
         engageDelayTicksRemaining = 0;  // Chase commands fire from tick 0
         engageCoastThrottle = static_cast<gp_scalar>(0.0);
@@ -633,12 +642,18 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       // pose is built from FDM post-reset state). Pre-fills 6-slot beacon
       // history with source[0] projection × 6, seeds crash hull PRNG,
       // resets NN recurrent state. No-op when mode != "tracker".
+      // 030 V1 priming — source library lives on the worker-resident
+      // init_; pathSelector indexes into init_.sourceList with modulo
+      // wraparound (matching minisim's mapping and the prior autoc-side
+      // sourceList[i % gSourceTrajectoryList.size()] behavior in
+      // buildEvalData pre-priming).
       if (trackerModeActive
-          && pathSelector < static_cast<int>(evalData.sourceList.size())
+          && !init_.sourceList.empty()
           && nnController_) {
-        const auto& source = evalData.sourceList.at(pathSelector);
+        const size_t srcIdx = static_cast<size_t>(pathSelector) % init_.sourceList.size();
+        const auto& source = init_.sourceList.at(srcIdx);
         if (!source.samples.empty()) {
-          trackerHelper_.initScenario(source, activeScenario, evalData,
+          trackerHelper_.initScenario(source, activeScenario, init_,
                                       aircraftState, *nnController_);
         }
       }
@@ -772,7 +787,7 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
     // 030 M11.preA — Rabbit odometer + path index advancement is pathgen-
     // specific. In tracker mode the source-cursor inside trackerHelper_
     // drives target progression instead.
-    const bool trackerActiveTick = (evalData.mode == Mode::TRACKER);
+    const bool trackerActiveTick = (init_.mode == Mode::TRACKER);
     if (!trackerActiveTick) {
       // Pathgen mode (existing): advance rabbit odometer + walk path.
       if (evalDtSec > 0.0f && evalDtSec < 1.0f) {  // Guard against huge jumps
@@ -848,9 +863,20 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       }
     }
 
-    // crashed or out of time or off the end of the list
-    if (crashReason != CrashReason::None)
-    {
+    // 030 V1.5 fix (2026-05-08) — bug in M11.preA: tracker arena egress /
+    // hull strike from helper.tick() was set on `crashReason` but the
+    // function had ALREADY passed this early-exit (helper.tick() runs
+    // later in the function), so the egress was silently ignored.
+    // Symptom: chase craft flew well outside the 80 m arena (max
+    // dhome=758 m observed) without recording a crash.
+    //
+    // Refactor: hoist the save+send+return body into a lambda
+    // (`finalizeScenarioOnCrash`) callable from BOTH the external-crash
+    // checkpoint here and a NEW post-NN-tick checkpoint below. Returns
+    // true when crash handled (caller must `return;`); false when the
+    // current tick is non-crash and execution should continue.
+    auto finalizeScenarioOnCrash = [&]() -> bool {
+      if (crashReason == CrashReason::None) return false;
 #ifdef DETAILED_LOGGING
       std::cout << "sim: " << crashReasonToString(crashReason) << " time: " << simTimeMsec << " idx: " << pathIndex << " size: " << path.size() << std::endl;
 #endif
@@ -859,7 +885,7 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       evalResults.crashReasonList.push_back(crashReason);
 
       // save the results list (with origin offset for renderer raw reconstruction)
-      ScenarioMetadata pathMeta = scenarioForPathIndex(evalData, static_cast<size_t>(pathSelector));
+      ScenarioMetadata pathMeta = makePerEvalMeta(init_, evalData, static_cast<size_t>(pathSelector));
       pathMeta.originOffset = pathOriginOffset;
       evalResults.scenarioList.push_back(pathMeta);
 
@@ -879,7 +905,7 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       // p_crash fires this scenario; arenaEgressCount = 1 if scenario
       // terminated via Eval (arena egress) else 0.
       evalResults.hullStrikeCount.push_back(
-          (evalData.mode == Mode::TRACKER) ? trackerHelper_.hullFiredCount() : 0);
+          (init_.mode == Mode::TRACKER) ? trackerHelper_.hullFiredCount() : 0);
       evalResults.arenaEgressCount.push_back(
           (crashReason == CrashReason::Eval) ? 1 : 0);
       // Only send physics trace data for elite reeval (expensive, only needed for divergence analysis)
@@ -921,9 +947,28 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
         evalResults.aircraftStateList.clear();
         evalResults.crashReasonList.clear();
         evalResults.scenarioList.clear();
+        // 030 V1.5 fix (2026-05-08) — pre-existing M11.preA leak: tracker
+        // mode + dmp recording vectors were appended each eval but never
+        // cleared post-send. After N evals, this evalResults carried
+        // N-evals-worth of cameraViewList / targetTrajectoryList — at
+        // pop=5000 / 20 workers / 294 scenarios this hit ~140 GB across
+        // worker contexts on autoc before gen 1 completed. minisim
+        // already has these clears; mirror them here.
+        evalResults.cameraViewList.clear();
+        evalResults.targetTrajectoryList.clear();
+        evalResults.arenaEgressCount.clear();
+        evalResults.hullStrikeCount.clear();
+        evalResults.debugSamples.clear();
+        evalResults.physicsTrace.clear();
       }
-      return;
-    }
+      return true;
+    };
+
+    // First crash checkpoint: external conditions set crashReason above
+    // (FDM STATE_CRASHED, TimeLimit, RabbitComplete, pathgen-mode raw OOB).
+    // Tracker arena egress / hull strike fire LATER (in helper.tick());
+    // they are caught at the second checkpoint after the NN tick block.
+    if (finalizeScenarioOnCrash()) return;
 
     // 030 M11.preA — Mode-aware NN evaluation block.
     //   Tracker mode: helper.tick() projects beacons + shifts history,
@@ -932,10 +977,11 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
     //     arena egress).
     //   Pathgen mode (existing): direction-cosine target-history capture,
     //     nnController_->evaluate against rabbit-odometer-driven path.
-    if (evalData.mode == Mode::TRACKER) {
+    if (init_.mode == Mode::TRACKER) {
       if (nnController_) {
         CrashReason trackerCrash =
-            trackerHelper_.tick(aircraftState, *nnController_, evalData);
+            trackerHelper_.tick(aircraftState, *nnController_, init_,
+                                evalData.pCrashThisGen);
         if (trackerCrash != CrashReason::None && crashReason == CrashReason::None) {
           crashReason = trackerCrash;
         }
@@ -981,6 +1027,14 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
 
     // Save post-eval state for results
     aircraftStates.push_back(aircraftState);
+
+    // 030 V1.5 fix (2026-05-08) — second crash checkpoint. helper.tick()
+    // above may have set crashReason from arena egress (FR-016) or hull
+    // strike (FR-008b); finalize the scenario here so the egress tick is
+    // recorded (aircraftStates.push_back above already captured it,
+    // matching minisim's stepOnce-then-push pattern). Pre-fix: tracker
+    // egress was silently ignored, chase craft flew unbounded.
+    if (finalizeScenarioOnCrash()) return;
     if (debugSamplesCurrentPath.size() < DEBUG_SAMPLE_LIMIT) {
       DebugSample sample;
       sample.pathIndex = pathSelector;

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -535,7 +535,7 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       // (rabbitOdometer/pathIndex/rabbitSpeedProfile/engageDelay are all
       // unused). Default-init them so the per-tick body's branches don't
       // see stale state from prior pathgen runs.
-      const bool trackerModeActive = (evalData.mode == "tracker");
+      const bool trackerModeActive = (evalData.mode == Mode::TRACKER);
       if (trackerModeActive) {
         engageDelayTicksRemaining = 0;  // Chase commands fire from tick 0
         engageCoastThrottle = static_cast<gp_scalar>(0.0);
@@ -772,7 +772,7 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
     // 030 M11.preA — Rabbit odometer + path index advancement is pathgen-
     // specific. In tracker mode the source-cursor inside trackerHelper_
     // drives target progression instead.
-    const bool trackerActiveTick = (evalData.mode == "tracker");
+    const bool trackerActiveTick = (evalData.mode == Mode::TRACKER);
     if (!trackerActiveTick) {
       // Pathgen mode (existing): advance rabbit odometer + walk path.
       if (evalDtSec > 0.0f && evalDtSec < 1.0f) {  // Guard against huge jumps
@@ -879,7 +879,7 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       // p_crash fires this scenario; arenaEgressCount = 1 if scenario
       // terminated via Eval (arena egress) else 0.
       evalResults.hullStrikeCount.push_back(
-          (evalData.mode == "tracker") ? trackerHelper_.hullFiredCount() : 0);
+          (evalData.mode == Mode::TRACKER) ? trackerHelper_.hullFiredCount() : 0);
       evalResults.arenaEgressCount.push_back(
           (crashReason == CrashReason::Eval) ? 1 : 0);
       // Only send physics trace data for elite reeval (expensive, only needed for divergence analysis)
@@ -932,7 +932,7 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
     //     arena egress).
     //   Pathgen mode (existing): direction-cosine target-history capture,
     //     nnController_->evaluate against rabbit-odometer-driven path.
-    if (evalData.mode == "tracker") {
+    if (evalData.mode == Mode::TRACKER) {
       if (nnController_) {
         CrashReason trackerCrash =
             trackerHelper_.tick(aircraftState, *nnController_, evalData);

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -100,17 +100,8 @@ AircraftState aircraftState;
 // Used to convert raw FDM position to virtual coordinates for AircraftState.
 gp_vec3 pathOriginOffset = gp_vec3::Zero();
 
-std::string crashReasonToString(CrashReason type) {
-  switch (type) {
-  case CrashReason::None: return "None";
-  case CrashReason::Boot: return "Boot";
-  case CrashReason::Sim: return "Sim";
-  case CrashReason::Eval: return "Eval";
-  case CrashReason::TimeLimit: return "TimeLimit";
-  case CrashReason::RabbitComplete: return "RabbitComplete";
-  default: return "*?*";
-  }
-}
+// crashReasonToString is now inline in include/autoc/rpc/crash_reason.h
+// (2026-05-11 — was duplicated across minisim.cc + this file).
 
 // Physics trace buffer for collecting detailed FDM state
 // Cleared at start of each evaluation, sent back with EvalResults only for elite reeval

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -528,12 +528,29 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       }
       gPendingCommand = PendingCommand{};
       aircraftStates.clear();
-      // Engage delay: coast for N ticks before NN outputs reach surfaces.
-      // Coast throttle derived from entry speed variation.
-      engageDelayTicksRemaining = static_cast<int>(
-          (engageDelayMsec + gEvalUpdateIntervalMsec - 1) / gEvalUpdateIntervalMsec);
-      engageCoastThrottle = static_cast<gp_scalar>(
-          CLAMP_DEF(2.0 * (activeScenario.entrySpeedFactor - 1.0), -1.0, 1.0));
+      // 030 M11.preA — clear per-path tracker buffers (no-op in pathgen mode)
+      trackerCameraViewSteps_.clear();
+      trackerTargetSampleSteps_.clear();
+      // 030 M11.preA — In tracker mode, skip pathgen scenario bookkeeping
+      // (rabbitOdometer/pathIndex/rabbitSpeedProfile/engageDelay are all
+      // unused). Default-init them so the per-tick body's branches don't
+      // see stale state from prior pathgen runs.
+      const bool trackerModeActive = (evalData.mode == "tracker");
+      if (trackerModeActive) {
+        engageDelayTicksRemaining = 0;  // Chase commands fire from tick 0
+        engageCoastThrottle = static_cast<gp_scalar>(0.0);
+        rabbitOdometer = 0.0f;
+        pathIndex = 0;
+        rabbitSpeedProfile.clear();
+        crrcsimRabbitSpeed = 0.0f;
+      } else {
+        // Pathgen mode (existing): engage delay + cruise throttle for
+        // INAV-handoff fidelity.
+        engageDelayTicksRemaining = static_cast<int>(
+            (engageDelayMsec + gEvalUpdateIntervalMsec - 1) / gEvalUpdateIntervalMsec);
+        engageCoastThrottle = static_cast<gp_scalar>(
+            CLAMP_DEF(2.0 * (activeScenario.entrySpeedFactor - 1.0), -1.0, 1.0));
+      }
       // Zero recurrent NN state at span start (spec 027 Q4: h_t resets
       // on new scenario; no-op for feedforward genomes).
       if (nnController_) nnController_->reset();
@@ -598,7 +615,8 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       aircraftState = initialState;
 
       // Pre-fill history buffer with initial geometry so the NN starts with
-      // consistent direction cosines instead of zeros.
+      // consistent direction cosines instead of zeros (pathgen-mode only;
+      // tracker mode uses TrackerHistoryWindow inside trackerHelper_ instead).
       {
         gp_vec3 tangent;
         if (path.size() > 1)
@@ -609,6 +627,20 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
         if (tn > 1e-6) tangent = tangent / tn;
         else tangent = gp_vec3::UnitX();
         aircraftState.resetHistory(path[0].start, tangent);
+      }
+
+      // 030 M11.preA — Tracker-mode helper scenario init (after chase
+      // pose is built from FDM post-reset state). Pre-fills 6-slot beacon
+      // history with source[0] projection × 6, seeds crash hull PRNG,
+      // resets NN recurrent state. No-op when mode != "tracker".
+      if (trackerModeActive
+          && pathSelector < static_cast<int>(evalData.sourceList.size())
+          && nnController_) {
+        const auto& source = evalData.sourceList.at(pathSelector);
+        if (!source.samples.empty()) {
+          trackerHelper_.initScenario(source, activeScenario, evalData,
+                                      aircraftState, *nnController_);
+        }
       }
 
       aircraftStates.push_back(aircraftState);
@@ -737,18 +769,22 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
     }
 
     // Advance rabbit odometer each eval tick (using dt computed before lastUpdateTimeMsec was updated)
-    // Rabbit speed varies over time (from per-scenario profile)
-    if (evalDtSec > 0.0f && evalDtSec < 1.0f) {  // Guard against huge jumps
-      double simTimeSec = simTimeMsec / 1000.0;
-      crrcsimRabbitSpeed = static_cast<gp_scalar>(
-          getSpeedAtTime(rabbitSpeedProfile, simTimeSec));
-      rabbitOdometer += crrcsimRabbitSpeed * evalDtSec;
-    }
-
-    // search for path segment by distance (odometer-based)
-    while (pathIndex < static_cast<int>(path.size()) - 2 && path.at(pathIndex).distanceFromStart < rabbitOdometer)
-    {
-      pathIndex++;
+    // 030 M11.preA — Rabbit odometer + path index advancement is pathgen-
+    // specific. In tracker mode the source-cursor inside trackerHelper_
+    // drives target progression instead.
+    const bool trackerActiveTick = (evalData.mode == "tracker");
+    if (!trackerActiveTick) {
+      // Pathgen mode (existing): advance rabbit odometer + walk path.
+      if (evalDtSec > 0.0f && evalDtSec < 1.0f) {  // Guard against huge jumps
+        double simTimeSec = simTimeMsec / 1000.0;
+        crrcsimRabbitSpeed = static_cast<gp_scalar>(
+            getSpeedAtTime(rabbitSpeedProfile, simTimeSec));
+        rabbitOdometer += crrcsimRabbitSpeed * evalDtSec;
+      }
+      while (pathIndex < static_cast<int>(path.size()) - 2 &&
+             path.at(pathIndex).distanceFromStart < rabbitOdometer) {
+        pathIndex++;
+      }
     }
 
     // Update sim state in AircraftState in-place to preserve temporal history
@@ -773,29 +809,43 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
 
     CrashReason crashReason = CrashReason::None;
 
-    // out of bounds? Use raw FDM position (not virtual from aircraftState)
-    gp_scalar distanceFromOrigin = std::sqrt(p[0] * p[0] + p[1] * p[1]);
-    if (p[2] < SIM_MAX_ELEVATION || // too high
-        p[2] > SIM_MIN_ELEVATION || // too low
-        distanceFromOrigin > SIM_PATH_RADIUS_LIMIT)
-    { // too far
-      crashReason = CrashReason::Eval;
+    // 030 M11.preA — Pathgen uses legacy SIM_PATH_RADIUS_LIMIT bounds +
+    // RabbitComplete (chase reached path end). Tracker uses FlightArena
+    // bounds via helper.tick() (already includes arena-egress + hull-strike
+    // checks), and source-exhaustion via helper.sourceExhausted().
+    if (!trackerActiveTick) {
+      // out of bounds? Use raw FDM position (not virtual from aircraftState)
+      gp_scalar distanceFromOrigin = std::sqrt(p[0] * p[0] + p[1] * p[1]);
+      if (p[2] < SIM_MAX_ELEVATION || // too high
+          p[2] > SIM_MIN_ELEVATION || // too low
+          distanceFromOrigin > SIM_PATH_RADIUS_LIMIT) {  // too far
+        crashReason = CrashReason::Eval;
+      }
     }
 
-    // sim crashed?
+    // sim crashed? — applies in BOTH modes (FDM-physics-NaN propagation, etc.)
     if (Global::Simulation->getState() == STATE_CRASHED)
     {
       crashReason = CrashReason::Sim;
     }
 
+    // Time limit applies in both modes.
     if (simTimeMsec > SIM_TOTAL_TIME_MSEC)
     {
       crashReason = CrashReason::TimeLimit;
     }
 
-    if (pathIndex >= path.size() - 3)
-    {
-      crashReason = CrashReason::RabbitComplete;
+    if (!trackerActiveTick) {
+      // Pathgen RabbitComplete (chase walked path to end).
+      if (pathIndex >= path.size() - 3) {
+        crashReason = CrashReason::RabbitComplete;
+      }
+    } else {
+      // Tracker source-exhaustion = "out of source samples" — semantically
+      // equivalent to RabbitComplete (scenario ran to end without crash).
+      if (trackerHelper_.sourceExhausted()) {
+        crashReason = CrashReason::RabbitComplete;
+      }
     }
 
     // crashed or out of time or off the end of the list
@@ -816,6 +866,22 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       std::vector<AircraftState> aircraftStatesCopy = aircraftStates;
       evalResults.aircraftStateList.push_back(aircraftStatesCopy);
       aircraftStates.clear();
+
+      // 030 M11.preA — Per-scenario tracker buffers into v=2 dmp fields.
+      // Pathgen mode pushes empty vectors (tracker buffers stay clear),
+      // matching minisim's behavior where pathgen dmps load with empty
+      // cameraViewList/targetTrajectoryList per the M8a schema contract.
+      evalResults.cameraViewList.push_back(trackerCameraViewSteps_);
+      evalResults.targetTrajectoryList.push_back(trackerTargetSampleSteps_);
+      trackerCameraViewSteps_.clear();
+      trackerTargetSampleSteps_.clear();
+      // Per-scenario telemetry counters (M7d.b). hullStrikeCount = hull
+      // p_crash fires this scenario; arenaEgressCount = 1 if scenario
+      // terminated via Eval (arena egress) else 0.
+      evalResults.hullStrikeCount.push_back(
+          (evalData.mode == "tracker") ? trackerHelper_.hullFiredCount() : 0);
+      evalResults.arenaEgressCount.push_back(
+          (crashReason == CrashReason::Eval) ? 1 : 0);
       // Only send physics trace data for elite reeval (expensive, only needed for divergence analysis)
       if (evalData.isEliteReeval) {
         if (!debugSamplesCurrentPath.empty()) {
@@ -859,35 +925,58 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       return;
     }
 
-    // Capture temporal history before NN evaluation (direction cosines, 023)
-    {
-      VectorPathProvider pathProvider(path, aircraftState.getThisPathIndex());
-      gp_vec3 targetPos = getInterpolatedTargetPosition(
-          pathProvider, rabbitOdometer, 0.0f);
-      gp_vec3 craftToTarget = targetPos - aircraftState.getPosition();
-      gp_vec3 target_local = aircraftState.getOrientation().inverse() * craftToTarget;
-      float distance = static_cast<float>(target_local.norm());
+    // 030 M11.preA — Mode-aware NN evaluation block.
+    //   Tracker mode: helper.tick() projects beacons + shifts history,
+    //     gathers TrackerInputs (45 floats including arena-distance), runs
+    //     evaluateTracker, returns per-tick crash signal (HullStrike or
+    //     arena egress).
+    //   Pathgen mode (existing): direction-cosine target-history capture,
+    //     nnController_->evaluate against rabbit-odometer-driven path.
+    if (evalData.mode == "tracker") {
+      if (nnController_) {
+        CrashReason trackerCrash =
+            trackerHelper_.tick(aircraftState, *nnController_, evalData);
+        if (trackerCrash != CrashReason::None && crashReason == CrashReason::None) {
+          crashReason = trackerCrash;
+        }
+      }
+      // Per-tick M2 dmp recording — push helper's lastCameraView /
+      // lastTargetSample into per-path buffers in lockstep with the
+      // aircraftStates push below. Pushed into evalResults at path-end.
+      trackerCameraViewSteps_.push_back(trackerHelper_.lastCameraView());
+      trackerTargetSampleSteps_.push_back(trackerHelper_.lastTargetSample());
+    } else {
+      // Pathgen mode (unchanged): capture temporal history (direction
+      // cosines, 023) before NN evaluation.
+      {
+        VectorPathProvider pathProvider(path, aircraftState.getThisPathIndex());
+        gp_vec3 targetPos = getInterpolatedTargetPosition(
+            pathProvider, rabbitOdometer, 0.0f);
+        gp_vec3 craftToTarget = targetPos - aircraftState.getPosition();
+        gp_vec3 target_local = aircraftState.getOrientation().inverse() * craftToTarget;
+        float distance = static_cast<float>(target_local.norm());
 
-      // Path tangent for singularity fallback
-      gp_vec3 posAhead = getInterpolatedTargetPosition(pathProvider, rabbitOdometer, 0.5f);
-      gp_vec3 tangent = posAhead - targetPos;
-      double tn = tangent.norm();
-      gp_vec3 tangent_body = (tn > 1e-6)
-          ? aircraftState.getOrientation().inverse() * (tangent / tn)
-          : gp_vec3::UnitX();
+        // Path tangent for singularity fallback
+        gp_vec3 posAhead = getInterpolatedTargetPosition(pathProvider, rabbitOdometer, 0.5f);
+        gp_vec3 tangent = posAhead - targetPos;
+        double tn = tangent.norm();
+        gp_vec3 tangent_body = (tn > 1e-6)
+            ? aircraftState.getOrientation().inverse() * (tangent / tn)
+            : gp_vec3::UnitX();
 
-      gp_vec3 dir = computeTargetDir(target_local, distance, tangent_body);
-      aircraftState.setRabbitPosition(targetPos);
-      aircraftState.recordErrorHistory(dir, distance, simTimeMsec);
-    }
+        gp_vec3 dir = computeTargetDir(target_local, distance, tangent_body);
+        aircraftState.setRabbitPosition(targetPos);
+        aircraftState.recordErrorHistory(dir, distance, simTimeMsec);
+      }
 
-    // Evaluate NN controller. Use the per-span member `nnController_` so
-    // recurrent hidden state (spec 027) persists across ticks. Fired on
-    // NN-eval cadence only — the `shouldEval` gate above enforces this,
-    // matching clarify Q4's hidden-state-advances-on-NN-tick contract.
-    if (nnController_) {
-      VectorPathProvider pathProvider(path, aircraftState.getThisPathIndex());
-      nnController_->evaluate(aircraftState, pathProvider);
+      // Evaluate pathgen NN controller. Use the per-span member
+      // `nnController_` so recurrent hidden state (spec 027) persists
+      // across ticks. Fired on NN-eval cadence only — the `shouldEval`
+      // gate above enforces this.
+      if (nnController_) {
+        VectorPathProvider pathProvider(path, aircraftState.getThisPathIndex());
+        nnController_->evaluate(aircraftState, pathProvider);
+      }
     }
 
     // Save post-eval state for results

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -505,17 +505,18 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
 
       // 030 V1.5 (2026-05-09 chase-init-geometry fix) — tracker mode places
       // chase 1.5 × trail_distance NORTH of source[0]=origin so chase starts
-      // 0.5 × trail_distance BEHIND trail-rabbit on the safe-cone side
-      // (gentle distScaleBehind=7m decay, tick-0 score ≈ 0.955 instead of
-      // the AT-rabbit knife-edge or worse the AHEAD-of-rabbit penalty zone
-      // chase fell into pre-fix because FDM defaulted to origin = on top of
-      // source). Chase is the only thing biased — source/rabbit dmp
-      // coordinates stay raw-as-recorded. Layered on top of the per-scenario
-      // entryNorthOffset variation (zero today since EntryPositionRadiusSigma=0;
-      // when re-enabled, variation perturbs around the trail-base position
-      // exactly per spec).
+      // 0.5 × trail_distance BEHIND trail-rabbit on the safe-cone side.
+      //
+      // Sign convention NOTE: crrcsim/src/crrc_main.cpp:258 does
+      // `posX += -Global::entryNorthOffset` — so positive entryNorthOffset
+      // moves chase SOUTH (-X), not north as the header comment claims.
+      // To bias chase NORTH (+X), we pass a NEGATIVE value into the global.
+      // The same sign-flip applies to per-scenario entryNorthOffset variations
+      // (when re-enabled via EntryPositionRadiusSigma > 0); the autoc-side
+      // variation pipeline preserves the convention upstream so we just
+      // pass through scenario value + our north-bias under the same sign.
       const gp_scalar trackerInitBiasNorth_m = (init_.mode == Mode::TRACKER)
-          ? static_cast<gp_scalar>(1.5) * init_.trailDistance
+          ? -static_cast<gp_scalar>(1.5) * init_.trailDistance
           : static_cast<gp_scalar>(0.0);
 
       // Entry position offsets (see specs/005-entry-fitness-ramp)

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -503,9 +503,24 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       Global::entrySpeedFactor = activeScenario.entrySpeedFactor;
       Global::windDirectionOffset = activeScenario.windDirectionOffset;
 
+      // 030 V1.5 (2026-05-09 chase-init-geometry fix) — tracker mode places
+      // chase 1.5 × trail_distance NORTH of source[0]=origin so chase starts
+      // 0.5 × trail_distance BEHIND trail-rabbit on the safe-cone side
+      // (gentle distScaleBehind=7m decay, tick-0 score ≈ 0.955 instead of
+      // the AT-rabbit knife-edge or worse the AHEAD-of-rabbit penalty zone
+      // chase fell into pre-fix because FDM defaulted to origin = on top of
+      // source). Chase is the only thing biased — source/rabbit dmp
+      // coordinates stay raw-as-recorded. Layered on top of the per-scenario
+      // entryNorthOffset variation (zero today since EntryPositionRadiusSigma=0;
+      // when re-enabled, variation perturbs around the trail-base position
+      // exactly per spec).
+      const gp_scalar trackerInitBiasNorth_m = (init_.mode == Mode::TRACKER)
+          ? static_cast<gp_scalar>(1.5) * init_.trailDistance
+          : static_cast<gp_scalar>(0.0);
+
       // Entry position offsets (see specs/005-entry-fitness-ramp)
       // Scenario offsets are NED meters; CRRCSim operates in feet
-      Global::entryNorthOffset = activeScenario.entryNorthOffset / FEET_TO_METERS;
+      Global::entryNorthOffset = (activeScenario.entryNorthOffset + trackerInitBiasNorth_m) / FEET_TO_METERS;
       Global::entryEastOffset = activeScenario.entryEastOffset / FEET_TO_METERS;
       Global::entryAltOffset = activeScenario.entryAltOffset / FEET_TO_METERS;
 

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -517,35 +517,35 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       lastUpdateTimeMsec = 0;
       pathIndex = 0;
       rabbitOdometer = 0.0f;
-      // Generate rabbit speed profile from per-scenario seed + global config
       rabbitSpeedConfig = evalData.rabbitSpeedConfig;
-      {
-        unsigned int seed = activeScenario.rabbitSpeedSeed;
-        double totalDurationSec = SIM_TOTAL_TIME_MSEC / 1000.0;
-        rabbitSpeedProfile = generateSpeedProfile(seed, rabbitSpeedConfig, totalDurationSec);
-        crrcsimRabbitSpeed = static_cast<gp_scalar>(
-            getSpeedAtTime(rabbitSpeedProfile, 0.0));
-      }
       gPendingCommand = PendingCommand{};
       aircraftStates.clear();
       // 030 M11.preA — clear per-path tracker buffers (no-op in pathgen mode)
       trackerCameraViewSteps_.clear();
       trackerTargetSampleSteps_.clear();
-      // 030 M11.preA — In tracker mode, skip pathgen scenario bookkeeping
-      // (rabbitOdometer/pathIndex/rabbitSpeedProfile/engageDelay are all
-      // unused). Default-init them so the per-tick body's branches don't
-      // see stale state from prior pathgen runs.
+      // 030 M11.preA — Mode-aware scenario bookkeeping. Pathgen needs the
+      // rabbit-speed profile, engage-delay timing, and cruise throttle for
+      // INAV-handoff fidelity. Tracker mode uses none of these (no synthetic
+      // rabbit, NN commands fire from tick 0). 2026-05-08 fix: previously
+      // generateSpeedProfile ran unconditionally and the result was
+      // discarded in tracker mode — wasted CPU + memory. Moved into else.
       const bool trackerModeActive = (evalData.mode == Mode::TRACKER);
       if (trackerModeActive) {
         engageDelayTicksRemaining = 0;  // Chase commands fire from tick 0
         engageCoastThrottle = static_cast<gp_scalar>(0.0);
-        rabbitOdometer = 0.0f;
-        pathIndex = 0;
         rabbitSpeedProfile.clear();
         crrcsimRabbitSpeed = 0.0f;
       } else {
-        // Pathgen mode (existing): engage delay + cruise throttle for
-        // INAV-handoff fidelity.
+        // Pathgen mode (existing): generate per-scenario rabbit-speed profile
+        // from autoc-side seed; engage delay + cruise throttle for INAV
+        // handoff fidelity.
+        {
+          unsigned int seed = activeScenario.rabbitSpeedSeed;
+          double totalDurationSec = SIM_TOTAL_TIME_MSEC / 1000.0;
+          rabbitSpeedProfile = generateSpeedProfile(seed, rabbitSpeedConfig, totalDurationSec);
+          crrcsimRabbitSpeed = static_cast<gp_scalar>(
+              getSpeedAtTime(rabbitSpeedProfile, 0.0));
+        }
         engageDelayTicksRemaining = static_cast<int>(
             (engageDelayMsec + gEvalUpdateIntervalMsec - 1) / gEvalUpdateIntervalMsec);
         engageCoastThrottle = static_cast<gp_scalar>(

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -36,6 +36,8 @@
 #include "autoc/eval/variation_generator.h"
 #include "autoc/util/socket_wrapper.h"
 
+#include "crrcsim_tracker_helper.h"   // 030 M11.preA
+
 #include <stdio.h>
 #include <iostream>
 #include <cmath>
@@ -146,6 +148,19 @@ private:
   NNGenome nnGenome;
   std::unique_ptr<NNControllerBackend> nnController_;
   std::vector<Path> path;
+
+  // 030 M11.preA — Tracker-mode helper (active when evalData.mode == "tracker").
+  // Encapsulates source-cursor + beacon history + crash hull + per-tick
+  // beacon projection / NN forward. Pathgen mode never touches this.
+  CrrcsimTrackerHelper trackerHelper_;
+
+  // 030 M11.preA — Per-path tracker-mode buffers, populated each NN tick
+  // from helper's lastCameraView/lastTargetSample. Pushed into
+  // evalResults.cameraViewList/targetTrajectoryList at path-end (mirrors
+  // minisim's M8b dmp output convention; keeps M2 dmp format identical
+  // across minisim/crrcsim per operator routing 2026-05-08).
+  std::vector<CameraViewSample> trackerCameraViewSteps_;
+  std::vector<CopiedTargetSample> trackerTargetSampleSteps_;
 };
 
 #endif

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -124,6 +124,13 @@ private:
   gp_scalar crrcsimRabbitSpeed = 0.0f;   // Set from speed profile at path start — 0 = uninitialized
   std::vector<RabbitSpeedPoint> rabbitSpeedProfile;  // Time-varying profile (generated per path)
   RabbitSpeedConfig rabbitSpeedConfig = RabbitSpeedConfig::defaultConfig();
+  // 030 V1 priming (2026-05-08) — once-per-worker payload received right
+  // after socket_ connects; carries scenario-static configs (mode, source
+  // library, camera, beacons, airframe, flight arena, pre-roll, crash hull
+  // radius, trail distance). Per-eval EvalData no longer carries them, so
+  // tracker training scales without OOM at pop=5000. See specs/BACKLOG.md
+  // "Worker-side scenario priming" entry.
+  WorkerInit init_;
   EvalData evalData;
   EvalResults evalResults;
   std::vector<AircraftState> aircraftStates;


### PR DESCRIPTION
## Summary

- Mirror the autoc-minisim `projectAndShiftHistory` extension (autoc PR #4 / commit `8520c04`) into `crrcsim_tracker_helper.cpp` so the crrcsim FDM worker populates `history.span[]` byte-equivalent to autoc's in-process path
- Adds `cepGateThreshold` read from `WorkerInit` (no `ConfigManager` on the crrcsim worker process)

## Why

Without this mirror, crrcsim bakes saw `history.span[]` all-zero across visible-beacon ticks because nothing populated it — derived feature B (span + span_rate) was silently dead, only tilt worked. Caught by inspecting data.dat in the first crrcsim relaunch (autoc commit `8520c04` had the autoc-side; this is the crrcsim-side parity).

## Test plan

- [x] Build clean (`make` from autoc build dir builds crrcsim too)
- [x] Full 800-gen tracker-mode bake completed using this commit's crrcsim — reached plateau-avgInRamp 0.158 (SUCCESS per autoc PR #4 spec Q7)
- [x] span / span_rate values verified present + sensible in data.dat throughout the bake

## Merge order

Per project convention ([feedback_submodule_merge_order]), this submodule PR merges **first**; the autoc parent PR (autoc#4) then merges with the bumped submodule pointer reachable from crrcsim main.

Companion autoc PR: https://github.com/gcmcnutt/autoc/pull/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)