### PR TITLE
crrcsim: 033–035 deltas (span mirror, scenarioSeed PRNG, craft-variation FDM, energy-era wind-seed gating)

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -65,3 +65,12 @@ double            Global::windDirectionOffset = 0.0;
 double            Global::entryNorthOffset = 0.0;
 double            Global::entryEastOffset = 0.0;
 double            Global::entryAltOffset = 0.0;
+
+// 034 US4 — craft variation carriers (defaults = no variation; additive
+// deltas at 0.0 and the thrust multiplier at 1.0 leave the FDM nominal).
+double            Global::craftCGDelta = 0.0;
+double            Global::craftDragDelta = 0.0;
+double            Global::craftTrimDelta = 0.0;
+double            Global::craftThrustScale = 1.0;
+double            Global::craftPitchEffDelta = 0.0;
+double            Global::craftRollEffDelta = 0.0;

--- a/src/global.h
+++ b/src/global.h
@@ -99,7 +99,7 @@ class Global
     // at the per-scenario reset hook, consumed in fdm_larcsim init/engine.
     // CG/trim/drag/pitch-eff/roll-eff are additive deltas (0.0 = nominal);
     // craftThrustScale is a multiplier (1.0 = nominal).
-    static double craftCGDelta;          ///< meters, CG arm offset
+    static double craftCGDelta;          ///< dimensionless CG arm offset (CRRCSim XML units, e.g. hb1_streamer nominal ≈ 0.28)
     static double craftDragDelta;        ///< fraction, CD_prof multiplier delta
     static double craftTrimDelta;        ///< radians, Cm_0 trim offset
     static double craftThrustScale;      ///< multiplier on engine maxThrust

--- a/src/global.h
+++ b/src/global.h
@@ -93,6 +93,18 @@ class Global
     static double entryNorthOffset;      ///< meters, NED North position offset
     static double entryEastOffset;       ///< meters, NED East position offset
     static double entryAltOffset;        ///< meters, NED Down altitude offset
+
+    // 034 US4 — craft variation parameters from ScenarioMetadata.craft*
+    // (AFTER worker-side applyVariationScale ramping). Set by inputdev_autoc
+    // at the per-scenario reset hook, consumed in fdm_larcsim init/engine.
+    // CG/trim/drag/pitch-eff/roll-eff are additive deltas (0.0 = nominal);
+    // craftThrustScale is a multiplier (1.0 = nominal).
+    static double craftCGDelta;          ///< meters, CG arm offset
+    static double craftDragDelta;        ///< fraction, CD_prof multiplier delta
+    static double craftTrimDelta;        ///< radians, Cm_0 trim offset
+    static double craftThrustScale;      ///< multiplier on engine maxThrust
+    static double craftPitchEffDelta;    ///< fraction, pitch-authority multiplier delta
+    static double craftRollEffDelta;     ///< fraction, roll-authority multiplier delta
 };
 
 

--- a/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
+++ b/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
@@ -28,6 +28,7 @@
 #include "fdm_larcsim.h"
 
 #include <math.h>
+#include "../../global.h"   // 034 US4 — Global::craft* per-scenario carriers
 #include <iostream>
 
 #include "../../mod_misc/ls_constants.h"
@@ -94,9 +95,22 @@ void CRRC_AirplaneSim_Larcsim::initAirplaneState(double dRelVel,
                                                  double Z,
                                                  double R_X,
                                                  double R_Y,
-                                                 double R_Z) 
+                                                 double R_Z)
 {
   float flVelocity = dRelVel * getTrimmedFlightVelocity();
+
+  // 034 US4 — apply per-scenario craft variations from Global::craft*
+  // carriers (set by inputdev_autoc per-scenario reset, already ramp-scaled
+  // by the autoc-side applyVariationScale pipeline). Additive deltas on
+  // CG/trim/drag/pitch-eff/roll-eff; multiplicative on thrust (handled in
+  // engine()). All-zero deltas (default / σ=0) collapse to nominal_X
+  // exactly, so a zero-σ run is bit-identical to a pre-034 LOAD-only run.
+  CG_arm  = nominal_CG_arm  + static_cast<SCALAR>(Global::craftCGDelta);
+  CD_prof = nominal_CD_prof * (static_cast<SCALAR>(1.0) + static_cast<SCALAR>(Global::craftDragDelta));
+  Cm_0    = nominal_Cm_0    + static_cast<SCALAR>(Global::craftTrimDelta);
+  Cm_de   = nominal_Cm_de   * (static_cast<SCALAR>(1.0) + static_cast<SCALAR>(Global::craftPitchEffDelta));
+  CL_de   = nominal_CL_de   * (static_cast<SCALAR>(1.0) + static_cast<SCALAR>(Global::craftPitchEffDelta));
+  Cl_da   = nominal_Cl_da   * (static_cast<SCALAR>(1.0) + static_cast<SCALAR>(Global::craftRollEffDelta));
 
   Phi       = dPhi;         // bank/roll angle  [rad]
   Theta     = dTheta;       // pitch attitude angle [rad]
@@ -346,7 +360,21 @@ void CRRC_AirplaneSim_Larcsim::LoadFromXML(SimpleXMLTransfer* xml, int nVerbosit
   Cn_r  = i->getDouble("Cn_r");
   Cn_dr = i->getDouble("Cn_dr");
   Cn_da = i->getDouble("Cn_da");
-    
+
+  // 034 US4 — cache the nominal aero/CG values so per-scenario craft
+  // variation deltas (applied in initAirplaneState from Global::craft*)
+  // can perturb consistently from a fixed reference. Setting them here
+  // means a worker that ever runs WITHOUT craft variations (all Global
+  // craft fields at default) sees identical aero behavior to a pre-034
+  // build — initAirplaneState's `nominal_X + 0.0` / `nominal_X * 1.0`
+  // simplify to `X = nominal_X`.
+  nominal_Cm_0    = Cm_0;
+  nominal_Cm_de   = Cm_de;
+  nominal_CL_de   = CL_de;
+  nominal_CD_prof = CD_prof;
+  nominal_CG_arm  = CG_arm;
+  nominal_Cl_da   = Cl_da;
+
   flap_drag      = aero->getDouble("flap.drag", 0);
   flap_lift      = aero->getDouble("flap.lift", 0);
   flap_moment    = aero->getDouble("flap.moment", 0);
@@ -492,6 +520,14 @@ void CRRC_AirplaneSim_Larcsim::engine( SCALAR dt, TSimInputs* inputs, CRRCMath::
   
   inputs->pitch = 1;
   power->step(dt, inputs, v_V_wind_body*FT_TO_M, &v_F, &v_M);
+
+  // 034 US4 — scale propeller thrust by per-scenario craft factor (default
+  // 1.0 ⇒ no-op). Counter-torque scales together with thrust since it
+  // physically tracks shaft power, which tracks force at constant prop
+  // geometry. Carrier (Global::craftThrustScale) is set per-scenario by
+  // inputdev_autoc after autoc-side applyVariationScale ramping.
+  v_F *= Global::craftThrustScale;
+  v_M *= Global::craftThrustScale;
 
   // Convert SI to that other buggy system.
   v_F *= N_TO_LBF;

--- a/src/mod_fdm/fdm_larcsim/fdm_larcsim.h
+++ b/src/mod_fdm/fdm_larcsim/fdm_larcsim.h
@@ -193,6 +193,19 @@ class CRRC_AirplaneSim_Larcsim : public EOM01
    SCALAR CG_arm;
    SCALAR CL_drop;
    SCALAR CD_stall;
+
+   // 034 US4 — nominal cache for craft-variation perturbation. Set ONCE at
+   // LOAD time from XML; reused every initAirplaneState to compute per-
+   // scenario perturbed values from Global::craft* (which arrived already
+   // ramp-scaled via the autoc->worker pipeline). Adding the cache instead
+   // of overwriting in-place preserves the LOAD-from-XML semantics so a
+   // re-init without craft variations falls back exactly to the nominal.
+   SCALAR nominal_Cm_0;
+   SCALAR nominal_Cm_de;
+   SCALAR nominal_CL_de;
+   SCALAR nominal_CD_prof;
+   SCALAR nominal_CG_arm;
+   SCALAR nominal_Cl_da;
    
    SCALAR span_eff;  // span efficiency: Effective span  0.95 for most planes, 0.85 flying wing
    SCALAR CL_CD0;    // CL at minimum profile CD: 0.30 for 7037, 0.15 MH32, 0.0 RG15, AGxx, power

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -17,6 +17,7 @@
 #include "autoc/eval/arena.h"
 #include "autoc/eval/derived_features.h"  // 032 phase 1 — compute_pair_span
 #include "autoc/eval/trail_rabbit.h"
+#include "autoc/util/scenario_prng.h"     // 033 — deriveClassSubSeeds
 
 using autoc::eval::CrashHull;
 using autoc::eval::ArenaEgressKind;
@@ -43,16 +44,26 @@ void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
     crash_hull_ = CrashHull{};
     crash_hull_.sphere_radius_m = init.crashHullRadius;
 
-    // PRNG seed = windSeed with anti-zero guard. Park-Miller LCG requires
-    // non-zero in [1, 2^31-2]. windSeed (NOT scenarioSequence) for
-    // determinism: scenarioSequence is a monotonic counter that differs
-    // between training-eval (seq=N) and elite-reeval (seq=N+~5000+) of the
-    // same scenario, which produced different LCG sequences → different
-    // didCrashFire Bernoulli draws → ELITE_DIVERGED warnings (2026-05-09).
-    // windSeed is per-scenario joint-PRNG-derived, stable across train/
-    // elite for the same scenario index. Same scenario → same hull-PRNG.
-    const uint32_t seed = static_cast<uint32_t>(meta.windSeed);
+    // 033 cleanup — crash-hull PRNG seed now derives from the RABBIT class
+    // sub-PRNG (per contracts/scenario_prng_chain.md — M2 crash-hull is
+    // a rabbit-class consumer). Pre-033 used meta.windSeed; that field
+    // has been removed. deriveClassSubSeeds(scenarioSeed) is the canonical
+    // route — autoc-side minisim TrackerStepper uses the same derivation
+    // path (deterministic across processes for the same scenarioSeed).
+    // anti-zero guard preserved (Park-Miller LCG breaks at state=0).
+    const auto subseeds = autoc::util::deriveClassSubSeeds(meta.scenarioSeed);
+    const uint32_t seed = subseeds.rabbit;
     prng_state_ = ((seed == 0 ? 0xC0FFEEu : seed % 0x7FFFFFFFu)) | 1u;
+
+    // 033 §2.B — capture smoothness config from WorkerInit; reset per-tick
+    // state. First-tick factor = 1.0 (no false-positive penalty on scenario
+    // entry). Mirror of TrackerStepper::initScenario smoothness reset.
+    smoothness_floor_ = init.smoothnessPenaltyFloor;
+    smoothness_mode_ = init.smoothnessMotionMode;
+    prev_out_valid_ = false;
+    prev_out_pt_ = static_cast<gp_scalar>(0.0);
+    prev_out_rl_ = static_cast<gp_scalar>(0.0);
+    prev_out_th_ = static_cast<gp_scalar>(0.0);
 
     // Reset NN recurrent state at scenario start (no-op for feedforward).
     nn.reset();
@@ -180,6 +191,39 @@ CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
     // (which inputdev_autoc.cpp's pending-command stage picks up post-tick).
     nn.evaluateTracker(chaseState, inputs);
 
+    // 033 §2.B — per-tick smoothness factor from NN-output Δs vs previous
+    // tick; store on chaseState for autoc-side fitness consumption (single
+    // source of truth: fitness_decomposition.cc reads getSmoothnessFactor()).
+    // Mirrors the autoc-side TrackerStepper::stepOnce smoothness compute.
+    // First tick (prev_out_valid_ = false) → Δs all zero → factor = 1.0.
+    {
+        const gp_scalar curr_pt = chaseState.getPitchCommand();
+        const gp_scalar curr_rl = chaseState.getRollCommand();
+        const gp_scalar curr_th = chaseState.getThrottleCommand();
+        gp_scalar dpt = static_cast<gp_scalar>(0.0);
+        gp_scalar drl = static_cast<gp_scalar>(0.0);
+        gp_scalar dth = static_cast<gp_scalar>(0.0);
+        if (prev_out_valid_) {
+            dpt = curr_pt - prev_out_pt_;
+            drl = curr_rl - prev_out_rl_;
+            dth = curr_th - prev_out_th_;
+        }
+        // Decode wire-stable uint8 enum → autoc::eval::SmoothnessMotionMode.
+        autoc::eval::SmoothnessMotionMode mode;
+        switch (smoothness_mode_) {
+            case 1: mode = autoc::eval::SmoothnessMotionMode::Sum; break;
+            case 2: mode = autoc::eval::SmoothnessMotionMode::Max; break;
+            default: mode = autoc::eval::SmoothnessMotionMode::Pythagorean; break;
+        }
+        const gp_scalar factor = autoc::eval::compute_smoothness_factor(
+            dpt, drl, dth, smoothness_floor_, mode);
+        chaseState.setSmoothnessFactor(factor);
+        prev_out_pt_ = curr_pt;
+        prev_out_rl_ = curr_rl;
+        prev_out_th_ = curr_th;
+        prev_out_valid_ = true;
+    }
+
     // Step 4: arena out-of-bounds via FR-016 FlightArena (same source-of-truth
     // as gather_tracker_inputs slot 44).
     {
@@ -190,8 +234,9 @@ CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
     }
 
     // 030 M11.preA.3 (2026-05-10) — Crash-hull RE-ENABLED with fixed
-    // Bernoulli probability per NN tick (10Hz). Seed = windSeed (P1 fix,
-    // stable train↔elite). Mirrors the parallel re-enable in
+    // Bernoulli probability per NN tick (10Hz). 033 cleanup: seed now
+    // derives from rabbit-class sub-PRNG via deriveClassSubSeeds (was
+    // meta.windSeed pre-cleanup). Mirrors the parallel re-enable in
     // src/eval/tracker_stepper.cc — keep both bodies in lockstep.
     if (crash == CrashReason::None) {
         if (didCrashFire(crash_hull_, chaseState.getPosition(), target.position,

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -55,16 +55,6 @@ void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
     const uint32_t seed = subseeds.rabbit;
     prng_state_ = ((seed == 0 ? 0xC0FFEEu : seed % 0x7FFFFFFFu)) | 1u;
 
-    // 033 §2.B — capture smoothness config from WorkerInit; reset per-tick
-    // state. First-tick factor = 1.0 (no false-positive penalty on scenario
-    // entry). Mirror of TrackerStepper::initScenario smoothness reset.
-    smoothness_floor_ = init.smoothnessPenaltyFloor;
-    smoothness_mode_ = init.smoothnessMotionMode;
-    prev_out_valid_ = false;
-    prev_out_pt_ = static_cast<gp_scalar>(0.0);
-    prev_out_rl_ = static_cast<gp_scalar>(0.0);
-    prev_out_th_ = static_cast<gp_scalar>(0.0);
-
     // Reset NN recurrent state at scenario start (no-op for feedforward).
     nn.reset();
 
@@ -191,39 +181,6 @@ CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
     // Step 3: NN forward pass → updates chaseState.pitch/roll/throttle commands
     // (which inputdev_autoc.cpp's pending-command stage picks up post-tick).
     nn.evaluateTracker(chaseState, inputs);
-
-    // 033 §2.B — per-tick smoothness factor from NN-output Δs vs previous
-    // tick; store on chaseState for autoc-side fitness consumption (single
-    // source of truth: fitness_decomposition.cc reads getSmoothnessFactor()).
-    // Mirrors the autoc-side TrackerStepper::stepOnce smoothness compute.
-    // First tick (prev_out_valid_ = false) → Δs all zero → factor = 1.0.
-    {
-        const gp_scalar curr_pt = chaseState.getPitchCommand();
-        const gp_scalar curr_rl = chaseState.getRollCommand();
-        const gp_scalar curr_th = chaseState.getThrottleCommand();
-        gp_scalar dpt = static_cast<gp_scalar>(0.0);
-        gp_scalar drl = static_cast<gp_scalar>(0.0);
-        gp_scalar dth = static_cast<gp_scalar>(0.0);
-        if (prev_out_valid_) {
-            dpt = curr_pt - prev_out_pt_;
-            drl = curr_rl - prev_out_rl_;
-            dth = curr_th - prev_out_th_;
-        }
-        // Decode wire-stable uint8 enum → autoc::eval::SmoothnessMotionMode.
-        autoc::eval::SmoothnessMotionMode mode;
-        switch (smoothness_mode_) {
-            case 1: mode = autoc::eval::SmoothnessMotionMode::Sum; break;
-            case 2: mode = autoc::eval::SmoothnessMotionMode::Max; break;
-            default: mode = autoc::eval::SmoothnessMotionMode::Pythagorean; break;
-        }
-        const gp_scalar factor = autoc::eval::compute_smoothness_factor(
-            dpt, drl, dth, smoothness_floor_, mode);
-        chaseState.setSmoothnessFactor(factor);
-        prev_out_pt_ = curr_pt;
-        prev_out_rl_ = curr_rl;
-        prev_out_th_ = curr_th;
-        prev_out_valid_ = true;
-    }
 
     // Step 4: arena out-of-bounds via FR-016 FlightArena (same source-of-truth
     // as gather_tracker_inputs slot 44).

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -185,7 +185,8 @@ CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
 
     // Step 2: gather tracker NN inputs.
     TrackerInputs inputs = {};
-    gather_tracker_inputs(chaseState, history_, init.flightArena, inputs);
+    gather_tracker_inputs(chaseState, history_, init.flightArena,
+                          static_cast<float>(init.cepGateThreshold), inputs);
 
     // Step 3: NN forward pass → updates chaseState.pitch/roll/throttle commands
     // (which inputdev_autoc.cpp's pending-command stage picks up post-tick).

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
@@ -101,16 +101,4 @@ private:
     CopiedTargetSample last_target_sample_{};
     // Reference to source samples — set in initScenario. NOT owned.
     const SourceScenarioTrajectory* source_ = nullptr;
-
-    // 033 §2.B — per-tick smoothness state (worker-side mirror of
-    // TrackerStepper::stepOnce smoothness compute). prev_out_valid_
-    // false at scenario start; first-tick factor = 1.0 per contract.
-    // smoothness_floor_ + smoothness_mode_ captured from WorkerInit at
-    // initScenario; stable per worker run.
-    gp_scalar smoothness_floor_ = static_cast<gp_scalar>(1.0);
-    uint8_t smoothness_mode_ = 0;  // 0=Pyth, 1=Sum, 2=Max (matches WorkerInit wire enum)
-    gp_scalar prev_out_pt_ = static_cast<gp_scalar>(0.0);
-    gp_scalar prev_out_rl_ = static_cast<gp_scalar>(0.0);
-    gp_scalar prev_out_th_ = static_cast<gp_scalar>(0.0);
-    bool prev_out_valid_ = false;
 };

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
@@ -15,10 +15,10 @@
 //   gather_tracker_inputs, computeTrailRabbit (via the tick body),
 //   CrashHull, FlightArena
 // - Determinism: zero wall-clock / thread-id state. PRNG seeded from
-//   scenarioMetadata.windSeed (joint-PRNG-derived, stable across
-//   training-eval and elite-reeval of the same scenario index — was
-//   scenarioSequence pre-2026-05-09 but that drifted seed values
-//   between train/elite calls, producing ELITE_DIVERGED warnings).
+//   the rabbit class sub-PRNG derived from scenarioMetadata.scenarioSeed
+//   via autoc::util::deriveClassSubSeeds (033 cleanup; pre-cleanup used
+//   meta.windSeed which has been removed). Stable across training-eval
+//   and elite-reeval of the same scenario index.
 
 #pragma once
 
@@ -37,8 +37,8 @@ class CrrcsimTrackerHelper {
 public:
     // Called at scenario boundary (analogous to TrackerStepper::initScenario):
     // - Cursor = 0
-    // - PRNG seeded from scenarioMetadata.windSeed (with anti-zero guard;
-    //   was scenarioSequence pre-2026-05-09 — see TU comment above)
+    // - PRNG seeded from rabbit-class sub-seed derived from
+    //   scenarioMetadata.scenarioSeed (033; see TU comment above)
     // - Crash hull initialized from WorkerInit (030 V1 priming —
     //   crashHullRadius lives on the once-per-worker WorkerInit, not in
     //   per-eval EvalData).
@@ -101,4 +101,16 @@ private:
     CopiedTargetSample last_target_sample_{};
     // Reference to source samples — set in initScenario. NOT owned.
     const SourceScenarioTrajectory* source_ = nullptr;
+
+    // 033 §2.B — per-tick smoothness state (worker-side mirror of
+    // TrackerStepper::stepOnce smoothness compute). prev_out_valid_
+    // false at scenario start; first-tick factor = 1.0 per contract.
+    // smoothness_floor_ + smoothness_mode_ captured from WorkerInit at
+    // initScenario; stable per worker run.
+    gp_scalar smoothness_floor_ = static_cast<gp_scalar>(1.0);
+    uint8_t smoothness_mode_ = 0;  // 0=Pyth, 1=Sum, 2=Max (matches WorkerInit wire enum)
+    gp_scalar prev_out_pt_ = static_cast<gp_scalar>(0.0);
+    gp_scalar prev_out_rl_ = static_cast<gp_scalar>(0.0);
+    gp_scalar prev_out_th_ = static_cast<gp_scalar>(0.0);
+    bool prev_out_valid_ = false;
 };

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -625,7 +625,8 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       std::cerr << "AUTOC deterministic path start pathSelector=" << pathSelector
                 << " pathVariant=" << activeScenario.pathVariantIndex
                 << " windVariant=" << activeScenario.windVariantIndex
-                << " windSeed=" << activeScenario.windSeed << std::endl;
+                << " scenarioSeed=0x" << std::hex << activeScenario.scenarioSeed
+                << std::dec << std::endl;  // 033: windSeed removed → scenarioSeed
 #endif
 
       // Record initial aircraft state at time 0 to match path start

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -29,7 +29,6 @@
 #include "../../mod_misc/crrc_rand.h"
 #include "../../mod_windfield/windfield.h"
 #include "inputdev_autoc.h"
-#include "autoc/eval/derived_features.h"     // 033 — compute_smoothness_factor + SmoothnessMotionMode
 #include "autoc/eval/scenario_meta_apply.h"  // 030 V1.5 — applyVariationScale
 #include "autoc/eval/variation_generator.h"
 #include "autoc/util/scenario_prng.h"        // 033 — deriveClassSubSeeds
@@ -580,15 +579,6 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
         engageCoastThrottle = static_cast<gp_scalar>(
             CLAMP_DEF(2.0 * (activeScenario.entrySpeedFactor - 1.0), -1.0, 1.0));
       }
-      // 033 §2.B — reset pathgen-mode smoothness prev-output state at
-      // path boundary. First-tick factor = 1.0 (no false-positive penalty
-      // on scenario entry). Tracker mode owns its own reset inside
-      // CrrcsimTrackerHelper::initScenario.
-      prev_out_valid_ = false;
-      prev_out_pt_ = static_cast<gp_scalar>(0.0);
-      prev_out_rl_ = static_cast<gp_scalar>(0.0);
-      prev_out_th_ = static_cast<gp_scalar>(0.0);
-
       // Zero recurrent NN state at span start (spec 027 Q4: h_t resets
       // on new scenario; no-op for feedforward genomes).
       if (nnController_) nnController_->reset();
@@ -1059,37 +1049,6 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       if (nnController_) {
         VectorPathProvider pathProvider(path, aircraftState.getThisPathIndex());
         nnController_->evaluate(aircraftState, pathProvider);
-      }
-
-      // 033 §2.B — per-tick smoothness factor (pathgen worker mirror).
-      // Compute from NN-output Δs vs prev tick; store on aircraftState
-      // for autoc-side fitness consumption (single source of truth).
-      // Mirrors PathgenStepper::stepOnce in autoc/src/eval/pathgen_stepper.cc.
-      {
-        const gp_scalar curr_pt = aircraftState.getPitchCommand();
-        const gp_scalar curr_rl = aircraftState.getRollCommand();
-        const gp_scalar curr_th = aircraftState.getThrottleCommand();
-        gp_scalar dpt = static_cast<gp_scalar>(0.0);
-        gp_scalar drl = static_cast<gp_scalar>(0.0);
-        gp_scalar dth = static_cast<gp_scalar>(0.0);
-        if (prev_out_valid_) {
-          dpt = curr_pt - prev_out_pt_;
-          drl = curr_rl - prev_out_rl_;
-          dth = curr_th - prev_out_th_;
-        }
-        autoc::eval::SmoothnessMotionMode mode;
-        switch (init_.smoothnessMotionMode) {
-          case 1: mode = autoc::eval::SmoothnessMotionMode::Sum; break;
-          case 2: mode = autoc::eval::SmoothnessMotionMode::Max; break;
-          default: mode = autoc::eval::SmoothnessMotionMode::Pythagorean; break;
-        }
-        const gp_scalar factor = autoc::eval::compute_smoothness_factor(
-            dpt, drl, dth, init_.smoothnessPenaltyFloor, mode);
-        aircraftState.setSmoothnessFactor(factor);
-        prev_out_pt_ = curr_pt;
-        prev_out_rl_ = curr_rl;
-        prev_out_th_ = curr_th;
-        prev_out_valid_ = true;
       }
     }
 

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -523,8 +523,9 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       // (worker calls applyVariationScale before this method runs), so the
       // values are already ramp-scaled per-eval. FDM init reads them once
       // at airplane reset (initAirplaneState) and engine maxThrust scaling.
-      // Cast through double for the gp_scalar→double FDM boundary (Global
-      // members are double for CRRCSim native math).
+      // raw-ok: gp_scalar→double cast at the autoc→crrcsim type-domain
+      // boundary (Global::* members are double for CRRCSim FDM native math
+      // per Constitution VI whitelist).
       Global::craftCGDelta       = static_cast<double>(activeScenario.craftCGDelta);
       Global::craftDragDelta     = static_cast<double>(activeScenario.craftDragDelta);
       Global::craftTrimDelta     = static_cast<double>(activeScenario.craftTrimDelta);

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -29,8 +29,10 @@
 #include "../../mod_misc/crrc_rand.h"
 #include "../../mod_windfield/windfield.h"
 #include "inputdev_autoc.h"
+#include "autoc/eval/derived_features.h"     // 033 — compute_smoothness_factor + SmoothnessMotionMode
 #include "autoc/eval/scenario_meta_apply.h"  // 030 V1.5 — applyVariationScale
 #include "autoc/eval/variation_generator.h"
+#include "autoc/util/scenario_prng.h"        // 033 — deriveClassSubSeeds
 #include <algorithm>
 #include <chrono>
 #include <stdio.h>
@@ -455,7 +457,8 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
 #ifdef DETAILED_LOGGING
       {
         const auto& firstScenario = evalResults.scenario;
-        std::cerr << "AUTOC deterministic wind seed=" << firstScenario.windSeed
+        std::cerr << "AUTOC deterministic scenarioSeed=0x" << std::hex
+                  << firstScenario.scenarioSeed << std::dec
                   << " pathVariant=" << firstScenario.pathVariantIndex
                   << " windVariant=" << firstScenario.windVariantIndex << std::endl;
       }
@@ -527,8 +530,16 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
                 << "m alt=" << Global::entryAltOffset << "m" << std::endl;
 #endif
 
-      // Reset simulation with wind seed
-      Global::Simulation->reset(activeScenario.windSeed);
+      // 033 cleanup — derive wind-class seed for CRRC_Random from
+      // meta.scenarioSeed. ClassPRNG(windSubSeed).next() is the
+      // operational wire-format value per contracts/scenario_prng_chain.md.
+      // Identical chain to autoc-side prefetch (same windPRNG init) →
+      // deterministic across processes for the same scenarioSeed.
+      const auto subseeds =
+          autoc::util::deriveClassSubSeeds(activeScenario.scenarioSeed);
+      autoc::util::ClassPRNG windPRNG(subseeds.wind);
+      const uint32_t windSimSeed = windPRNG.next();
+      Global::Simulation->reset(windSimSeed);
       simCrashed = false;
       lastUpdateTimeMsec = 0;
       pathIndex = 0;
@@ -553,10 +564,12 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
         crrcsimRabbitSpeed = 0.0f;
       } else {
         // Pathgen mode (existing): generate per-scenario rabbit-speed profile
-        // from autoc-side seed; engage delay + cruise throttle for INAV
-        // handoff fidelity.
+        // from the RABBIT-class sub-PRNG (033 cleanup — was activeScenario.
+        // rabbitSpeedSeed pre-cleanup; field removed). Same scenarioSeed →
+        // same rabbit-class seed → same speed profile across runs.
+        // `subseeds` was derived above for the wind path; reuse it here.
         {
-          unsigned int seed = activeScenario.rabbitSpeedSeed;
+          unsigned int seed = subseeds.rabbit;
           double totalDurationSec = SIM_TOTAL_TIME_MSEC / 1000.0;
           rabbitSpeedProfile = generateSpeedProfile(seed, rabbitSpeedConfig, totalDurationSec);
           crrcsimRabbitSpeed = static_cast<gp_scalar>(
@@ -567,6 +580,15 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
         engageCoastThrottle = static_cast<gp_scalar>(
             CLAMP_DEF(2.0 * (activeScenario.entrySpeedFactor - 1.0), -1.0, 1.0));
       }
+      // 033 §2.B — reset pathgen-mode smoothness prev-output state at
+      // path boundary. First-tick factor = 1.0 (no false-positive penalty
+      // on scenario entry). Tracker mode owns its own reset inside
+      // CrrcsimTrackerHelper::initScenario.
+      prev_out_valid_ = false;
+      prev_out_pt_ = static_cast<gp_scalar>(0.0);
+      prev_out_rl_ = static_cast<gp_scalar>(0.0);
+      prev_out_th_ = static_cast<gp_scalar>(0.0);
+
       // Zero recurrent NN state at span start (spec 027 Q4: h_t resets
       // on new scenario; no-op for feedforward genomes).
       if (nnController_) nnController_->reset();
@@ -900,12 +922,20 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       evalResults.aircraftStateList.push_back(aircraftStatesCopy);
       aircraftStates.clear();
 
-      // 030 M11.preA — Per-scenario tracker buffers into v=2 dmp fields.
-      // Pathgen mode pushes empty vectors (tracker buffers stay clear),
-      // matching minisim's behavior where pathgen dmps load with empty
-      // cameraViewList/targetTrajectoryList per the M8a schema contract.
-      evalResults.cameraViewList.push_back(trackerCameraViewSteps_);
-      evalResults.targetTrajectoryList.push_back(trackerTargetSampleSteps_);
+      // 033 troubleshooting 2026-05-22 — bug fix mirror of the same fix in
+      // tools/minisim.cc: cameraViewList + targetTrajectoryList are
+      // TRACKER-MODE-ONLY per the EvalResults contract (protocol.h:359
+      // "Empty in pathgen-mode dmps"). Prior unconditional push_back of
+      // (empty in pathgen) inner vectors produced an outer-vector-non-
+      // empty dmp that the renderer (renderer.cc:400-402 dispatches on
+      // outer-vector emptiness) mis-classified as tracker mode → rabbit
+      // path render skipped. Pathgen workers leave the trackerCameraViewSteps_
+      // / trackerTargetSampleSteps_ buffers empty all along; gating the
+      // push restores the documented contract.
+      if (init_.mode == Mode::TRACKER) {
+        evalResults.cameraViewList.push_back(trackerCameraViewSteps_);
+        evalResults.targetTrajectoryList.push_back(trackerTargetSampleSteps_);
+      }
       trackerCameraViewSteps_.clear();
       trackerTargetSampleSteps_.clear();
       // Per-scenario telemetry counters (M7d.b). hullStrikeCount = hull
@@ -1029,6 +1059,37 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       if (nnController_) {
         VectorPathProvider pathProvider(path, aircraftState.getThisPathIndex());
         nnController_->evaluate(aircraftState, pathProvider);
+      }
+
+      // 033 §2.B — per-tick smoothness factor (pathgen worker mirror).
+      // Compute from NN-output Δs vs prev tick; store on aircraftState
+      // for autoc-side fitness consumption (single source of truth).
+      // Mirrors PathgenStepper::stepOnce in autoc/src/eval/pathgen_stepper.cc.
+      {
+        const gp_scalar curr_pt = aircraftState.getPitchCommand();
+        const gp_scalar curr_rl = aircraftState.getRollCommand();
+        const gp_scalar curr_th = aircraftState.getThrottleCommand();
+        gp_scalar dpt = static_cast<gp_scalar>(0.0);
+        gp_scalar drl = static_cast<gp_scalar>(0.0);
+        gp_scalar dth = static_cast<gp_scalar>(0.0);
+        if (prev_out_valid_) {
+          dpt = curr_pt - prev_out_pt_;
+          drl = curr_rl - prev_out_rl_;
+          dth = curr_th - prev_out_th_;
+        }
+        autoc::eval::SmoothnessMotionMode mode;
+        switch (init_.smoothnessMotionMode) {
+          case 1: mode = autoc::eval::SmoothnessMotionMode::Sum; break;
+          case 2: mode = autoc::eval::SmoothnessMotionMode::Max; break;
+          default: mode = autoc::eval::SmoothnessMotionMode::Pythagorean; break;
+        }
+        const gp_scalar factor = autoc::eval::compute_smoothness_factor(
+            dpt, drl, dth, init_.smoothnessPenaltyFloor, mode);
+        aircraftState.setSmoothnessFactor(factor);
+        prev_out_pt_ = curr_pt;
+        prev_out_rl_ = curr_rl;
+        prev_out_th_ = curr_th;
+        prev_out_valid_ = true;
       }
     }
 

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -518,6 +518,20 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       Global::entryEastOffset = activeScenario.entryEastOffset / FEET_TO_METERS;
       Global::entryAltOffset = activeScenario.entryAltOffset / FEET_TO_METERS;
 
+      // 034 US4 — craft variation parameters from ScenarioMetadata. These
+      // arrive in this metadata block AFTER autoc-side applyVariationScale
+      // (worker calls applyVariationScale before this method runs), so the
+      // values are already ramp-scaled per-eval. FDM init reads them once
+      // at airplane reset (initAirplaneState) and engine maxThrust scaling.
+      // Cast through double for the gp_scalar→double FDM boundary (Global
+      // members are double for CRRCSim native math).
+      Global::craftCGDelta       = static_cast<double>(activeScenario.craftCGDelta);
+      Global::craftDragDelta     = static_cast<double>(activeScenario.craftDragDelta);
+      Global::craftTrimDelta     = static_cast<double>(activeScenario.craftTrimDelta);
+      Global::craftThrustScale   = static_cast<double>(activeScenario.craftThrustScale);
+      Global::craftPitchEffDelta = static_cast<double>(activeScenario.craftPitchEffDelta);
+      Global::craftRollEffDelta  = static_cast<double>(activeScenario.craftRollEffDelta);
+
 #ifdef DETAILED_LOGGING
       std::cerr << "VARIATIONS1: heading=" << (Global::entryHeadingOffset * 180.0/M_PI)
                 << "° roll=" << (Global::entryRollOffset * 180.0/M_PI)

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -549,10 +549,22 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       // operational wire-format value per contracts/scenario_prng_chain.md.
       // Identical chain to autoc-side prefetch (same windPRNG init) →
       // deterministic across processes for the same scenarioSeed.
+      //
+      // 034 Phase 7 — when EnableWindVariations=0, the per-scenario
+      // randomization here was breaking the craft-isolation experiment:
+      // all scenarios saw different gust/thermal sequences even though
+      // the autoc-side meta.windDirectionOffset was zeroed. Now we draw
+      // the per-scenario seed regardless (draw-and-discard: preserves
+      // cross-class determinism if the flag is toggled) but feed the sim
+      // a fixed kDisabledWindSeed when the master enable is off — so
+      // every scenario flies through identical wind/gusts.
+      static constexpr uint32_t kDisabledWindSeed = 0xC0FFEEu;
       const auto subseeds =
           autoc::util::deriveClassSubSeeds(activeScenario.scenarioSeed);
       autoc::util::ClassPRNG windPRNG(subseeds.wind);
-      const uint32_t windSimSeed = windPRNG.next();
+      const uint32_t drawnWindSeed = windPRNG.next();
+      const uint32_t windSimSeed = init_.enableWindVariations
+          ? drawnWindSeed : kDisabledWindSeed;
       Global::Simulation->reset(windSimSeed);
       simCrashed = false;
       lastUpdateTimeMsec = 0;

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -135,14 +135,6 @@ private:
   EvalResults evalResults;
   std::vector<AircraftState> aircraftStates;
 
-  // 033 §2.B — per-tick smoothness state for PATHGEN mode (tracker mode
-  // owns its own prev_out tracking inside CrrcsimTrackerHelper). Reset
-  // at path boundary (where priorPathSelector != pathSelector). First-
-  // tick factor = 1.0 (prev_out_valid_ = false). Mirrors PathgenStepper.
-  gp_scalar prev_out_pt_ = static_cast<gp_scalar>(0.0);
-  gp_scalar prev_out_rl_ = static_cast<gp_scalar>(0.0);
-  gp_scalar prev_out_th_ = static_cast<gp_scalar>(0.0);
-  bool prev_out_valid_ = false;
   std::vector<DebugSample> debugSamplesCurrentPath;
   double quatDotPast[4] = {0,0,0,0};
   int workerIndex = -1;

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -134,6 +134,15 @@ private:
   EvalData evalData;
   EvalResults evalResults;
   std::vector<AircraftState> aircraftStates;
+
+  // 033 §2.B — per-tick smoothness state for PATHGEN mode (tracker mode
+  // owns its own prev_out tracking inside CrrcsimTrackerHelper). Reset
+  // at path boundary (where priorPathSelector != pathSelector). First-
+  // tick factor = 1.0 (prev_out_valid_ = false). Mirrors PathgenStepper.
+  gp_scalar prev_out_pt_ = static_cast<gp_scalar>(0.0);
+  gp_scalar prev_out_rl_ = static_cast<gp_scalar>(0.0);
+  gp_scalar prev_out_th_ = static_cast<gp_scalar>(0.0);
+  bool prev_out_valid_ = false;
   std::vector<DebugSample> debugSamplesCurrentPath;
   double quatDotPast[4] = {0,0,0,0};
   int workerIndex = -1;


### PR DESCRIPTION
## Summary
Lands the crrcsim source half of features **033, 034, and 035** to `main`. The 035 parent (autoc #5)
records this commit (`255e43d`) as its submodule pointer, but crrcsim `main` is 7 commits behind —
033's and 034's crrcsim work was never merged (stranded on their branches). 035 itself added **no new
crrcsim source**, so this PR is the inherited 033/034 deltas plus 035's pointer.

## Commits (7)
- `255e43d` fix(034): stale windSeed ref in DETAILED_LOGGING path → scenarioSeed
- `244bb37` feat(034 Phase 7): gate per-scenario wind seed on EnableWindVariations
- `0f7db0f` chore(034 US4): annotate gp_scalar→double FDM boundary + fix CG unit comment
- `791d97c` checkpoint(034 US4): craft variation FDM apply
- `fee0fb8` checkpoint(034 US2): remove crrcsim smoothness mirror
- `19b6367` fix(032/033): pass cep_gate_threshold to gather_tracker_inputs
- `ed9b1bb` feat(033): scenarioSeed-derived class PRNGs + per-tick smoothness mirror

## Merge order
**Merge this BEFORE autoc PR #5** (submodule pointer first, parent second). `255e43d` is a clean
fast-forward descendant of main's current crrcsim pointer (`e3d623f`) — no divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)