### PR TITLE
037: in-FDM actuator dynamics + servo model v2 (20 Hz cadence)

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -78,7 +78,6 @@ double            Global::craftRollEffDelta = 0.0;
 // 037 actuator dynamics (operator decision: in-FDM, substep dt). Defaults =
 // nominal centers (see craft_variation.h kCraft*Center): a no-craft run runs
 // the nominal lag model rather than a bypassed pass-through.
-double            Global::servoTau = 0.020;   // s (v2: unused by the FDM)
 double            Global::servoSlew = 24.0;   // /s (autoc [-1,1] command units, v2 center ~24.2)
 double            Global::thrustTau = 0.150;  // s
 bool              Global::servoModelEnabled = false;  // 037 servo v2 switch (WorkerInit)

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -78,6 +78,8 @@ double            Global::craftRollEffDelta = 0.0;
 // 037 actuator dynamics (operator decision: in-FDM, substep dt). Defaults =
 // nominal centers (see craft_variation.h kCraft*Center): a no-craft run runs
 // the nominal lag model rather than a bypassed pass-through.
-double            Global::servoTau = 0.020;   // s
-double            Global::servoSlew = 6.0;    // /s (full-throw/s)
+double            Global::servoTau = 0.020;   // s (v2: unused by the FDM)
+double            Global::servoSlew = 12.0;   // /s (full-throw/s, v2 center)
 double            Global::thrustTau = 0.150;  // s
+bool              Global::servoModelEnabled = false;  // 037 servo v2 switch (WorkerInit)
+double            Global::servoPwmPhase = 0.0;        // s, per-scenario PWM latch phase

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -74,3 +74,10 @@ double            Global::craftTrimDelta = 0.0;
 double            Global::craftThrustScale = 1.0;
 double            Global::craftPitchEffDelta = 0.0;
 double            Global::craftRollEffDelta = 0.0;
+
+// 037 actuator dynamics (operator decision: in-FDM, substep dt). Defaults =
+// nominal centers (see craft_variation.h kCraft*Center): a no-craft run runs
+// the nominal lag model rather than a bypassed pass-through.
+double            Global::servoTau = 0.020;   // s
+double            Global::servoSlew = 6.0;    // /s (full-throw/s)
+double            Global::thrustTau = 0.150;  // s

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -79,7 +79,7 @@ double            Global::craftRollEffDelta = 0.0;
 // nominal centers (see craft_variation.h kCraft*Center): a no-craft run runs
 // the nominal lag model rather than a bypassed pass-through.
 double            Global::servoTau = 0.020;   // s (v2: unused by the FDM)
-double            Global::servoSlew = 12.0;   // /s (full-throw/s, v2 center)
+double            Global::servoSlew = 24.0;   // /s (autoc [-1,1] command units, v2 center ~24.2)
 double            Global::thrustTau = 0.150;  // s
 bool              Global::servoModelEnabled = false;  // 037 servo v2 switch (WorkerInit)
 double            Global::servoPwmPhase = 0.0;        // s, per-scenario PWM latch phase

--- a/src/global.h
+++ b/src/global.h
@@ -112,9 +112,17 @@ class Global
     // by inputdev_autoc AFTER worker-side applyVariationScale ramping;
     // consumed each FDM substep in fdm_larcsim. Defaults = nominal centers so
     // a no-craft run still runs the nominal lag model.
-    static double servoTau;              ///< s, servo first-order lag time constant (center 0.020)
-    static double servoSlew;             ///< /s, servo slew-rate limit, full-throw/s (center 6.0)
+    static double servoTau;              ///< s, servo first-order lag time constant — v2: UNUSED by the FDM (kept for wire/draw stability)
+    static double servoSlew;             ///< /s, servo slew-rate limit, full-throw/s (v2 center ≈12.1 from the 0.07s/60° DSM-44 transit)
     static double thrustTau;             ///< s, thrust first-order lag time constant (center 0.150)
+
+    // 037 servo v2 (operator 2026-06-11, post-t6/t7 A/B): datasheet-shaped
+    // servo = 50 Hz PWM command LATCH (per-scenario phase = the 0-20 ms
+    // dead-time) + pure slew toward the latched target. Gated by
+    // servoModelEnabled (WorkerInit.servoModelEnabled <- ServoModelEnabled
+    // ini knob) so A/B run pairs differ by ini only.
+    static bool servoModelEnabled;       ///< master switch for the in-FDM servo block
+    static double servoPwmPhase;         ///< s, per-scenario PWM latch phase, [0, 0.020)
 };
 
 

--- a/src/global.h
+++ b/src/global.h
@@ -113,7 +113,7 @@ class Global
     // consumed each FDM substep in fdm_larcsim. Defaults = nominal centers so
     // a no-craft run still runs the nominal lag model.
     static double servoTau;              ///< s, servo first-order lag time constant — v2: UNUSED by the FDM (kept for wire/draw stability)
-    static double servoSlew;             ///< /s, servo slew-rate limit, full-throw/s (v2 center ≈12.1 from the 0.07s/60° DSM-44 transit)
+    static double servoSlew;             ///< /s, servo slew-rate limit in autoc [-1,1] command units (full span = 2.0 units; v2 center ≈24.2 from the DSM-44 transit — see autoc craft_variation.h)
     static double thrustTau;             ///< s, thrust first-order lag time constant (center 0.150)
 
     // 037 servo v2 (operator 2026-06-11, post-t6/t7 A/B): datasheet-shaped

--- a/src/global.h
+++ b/src/global.h
@@ -105,6 +105,16 @@ class Global
     static double craftThrustScale;      ///< multiplier on engine maxThrust
     static double craftPitchEffDelta;    ///< fraction, pitch-authority multiplier delta
     static double craftRollEffDelta;     ///< fraction, roll-authority multiplier delta
+
+    // 037 actuator dynamics (operator decision: in-FDM, substep dt).
+    // Absolute physical parameters for the in-FDM actuator filter (servo
+    // lag+slew on aileron/elevator, first-order thrust lag). Set per-scenario
+    // by inputdev_autoc AFTER worker-side applyVariationScale ramping;
+    // consumed each FDM substep in fdm_larcsim. Defaults = nominal centers so
+    // a no-craft run still runs the nominal lag model.
+    static double servoTau;              ///< s, servo first-order lag time constant (center 0.020)
+    static double servoSlew;             ///< /s, servo slew-rate limit, full-throw/s (center 6.0)
+    static double thrustTau;             ///< s, thrust first-order lag time constant (center 0.150)
 };
 
 

--- a/src/global.h
+++ b/src/global.h
@@ -107,12 +107,12 @@ class Global
     static double craftRollEffDelta;     ///< fraction, roll-authority multiplier delta
 
     // 037 actuator dynamics (operator decision: in-FDM, substep dt).
-    // Absolute physical parameters for the in-FDM actuator filter (servo
-    // lag+slew on aileron/elevator, first-order thrust lag). Set per-scenario
-    // by inputdev_autoc AFTER worker-side applyVariationScale ramping;
-    // consumed each FDM substep in fdm_larcsim. Defaults = nominal centers so
-    // a no-craft run still runs the nominal lag model.
-    static double servoTau;              ///< s, servo first-order lag time constant — v2: UNUSED by the FDM (kept for wire/draw stability)
+    // Absolute physical parameters for the in-FDM actuator filter (servo slew
+    // on aileron/elevator, first-order thrust lag). Set per-scenario by
+    // inputdev_autoc AFTER worker-side applyVariationScale ramping; consumed
+    // each FDM substep in fdm_larcsim. Defaults = nominal centers so a
+    // no-craft run still runs the nominal model. (servo first-order tau
+    // removed 2026-06-12 — v2 PWM-latch+slew has no lag term.)
     static double servoSlew;             ///< /s, servo slew-rate limit in autoc [-1,1] command units (full span = 2.0 units; v2 center ≈24.2 from the DSM-44 transit — see autoc craft_variation.h)
     static double thrustTau;             ///< s, thrust first-order lag time constant (center 0.150)
 

--- a/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
+++ b/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
@@ -116,12 +116,22 @@ void CRRC_AirplaneSim_Larcsim::initAirplaneState(double dRelVel,
   // 037 actuator dynamics (operator decision: in-FDM, substep dt). Reset the
   // persistent actuator-filter state at scenario reset so a fresh scenario
   // starts from neutral surfaces and full commanded thrust, not the previous
-  // flight's lagged state. Servo surfaces start neutral (0.0); the thrust
+  // flight's state. Servo surfaces + latches start neutral (0.0); the thrust
   // lag state starts at 1.0 (full applied scale) so the very first lag step
   // is a no-op until power->step produces a commanded thrust.
-  servoStateAileron  = static_cast<SCALAR>(0.0);
-  servoStateElevator = static_cast<SCALAR>(0.0);
-  thrustStateScale   = static_cast<SCALAR>(1.0);
+  //
+  // 037 servo v2: the PWM timer starts at (frame - phase) so the FIRST latch
+  // lands exactly `phase` seconds into the scenario (phase = per-scenario
+  // craft draw, uniform [0, 20) ms — the engage episode's alignment within
+  // the 50 Hz command frame), then every 20 ms after. Deterministic: phase
+  // is scenario-static, dt arithmetic only.
+  servoStateAileron    = static_cast<SCALAR>(0.0);
+  servoStateElevator   = static_cast<SCALAR>(0.0);
+  servoLatchedAileron  = static_cast<SCALAR>(0.0);
+  servoLatchedElevator = static_cast<SCALAR>(0.0);
+  servoPwmTimerSec     = static_cast<SCALAR>(0.020)
+      - static_cast<SCALAR>(Global::servoPwmPhase);
+  thrustStateScale     = static_cast<SCALAR>(1.0);
 
   Phi       = dPhi;         // bank/roll angle  [rad]
   Theta     = dTheta;       // pitch attitude angle [rad]
@@ -235,66 +245,70 @@ void CRRC_AirplaneSim_Larcsim::update(TSimInputs* inputs,
 
     env->ControllerCallback(dt, this, inputs, &myInputs);
 
-    // 037 actuator dynamics (operator decision: in-FDM, substep dt). Apply a
-    // per-channel servo model (slew-rate limit + first-order lag) to the
-    // aileron/elevator surface commands BEFORE they feed the aero force/moment
-    // calc and the engine call. This is a FDM physics filter on the command
-    // surface -- NOT a command-path filter in the controller. dt here is the
-    // LaRCSim per-substep integration step (the same dt passed to ls_step and
-    // engine), not the outer frame interval. Pure deterministic arithmetic on
-    // dt -- no PRNG. With the nominal centers (servoTau 0.020 s, servoSlew 6.0
-    // full-throw/s) this is a small but non-zero lag, so a no-variation run
-    // differs from pre-037 ONLY by this intended nominal lag model.
+    // 037 servo model v2 (operator 2026-06-11, post-t6/t7 A/B — see
+    // specs/037-20hz-control-loop/outcome.md + the DSM-44 datasheet check in
+    // finding.md). The v1 lag-dominant filter (tau 20 ms + slew 3–9/s, shaded
+    // slow vs the datasheet) capped tracking entirely; v1 history is in git
+    // (removed here, was the #if 0 block from the t7 A/B). v2 is
+    // datasheet-shaped, two components:
+    //
+    //   1. PWM command LATCH: the servo samples its command pulse once per
+    //      50 Hz frame (20 ms). The latch fires when the per-substep timer
+    //      crosses the frame boundary; the per-scenario phase
+    //      (Global::servoPwmPhase, uniform [0,20) ms, craft-class draw) is
+    //      the engage episode's arbitrary alignment within the frame — the
+    //      operator's "0–20 ms PWM lag jitter". Between latches the target
+    //      is FROZEN (true dead-time: delays, does not smooth).
+    //   2. Pure SLEW toward the latched target, from the measured transit
+    //      (~55 ms per 60° on a ~90° span ⇒ center ≈12.1 full-throw/s,
+    //      per-scenario draw clamped 8–16). No first-order lag in v2 —
+    //      a digital micro's small-signal settle is sub-frame; the latch
+    //      supplies the delay, the slew supplies the transit.
+    //
+    // Gated on Global::servoModelEnabled (ServoModelEnabled ini knob via
+    // WorkerInit) so A/B pairs (t8 off / t9 on) differ by ini only.
+    // Deterministic: pure dt arithmetic + per-scenario state reset in
+    // initAirplaneState; no PRNG here.
     //
     // Surface convention: TSimInputs aileron/elevator are in [-0.5, 0.5]
     // (full throw magnitude = 0.5). servoSlew is in full-throw/s where
     // full-throw = 1.0 (the [-1,1] crrcsim convention), so the per-substep
     // surface-unit slew cap is 0.5 * servoSlew * dt.
-    //
-    // 037 t7 A/B (operator 2026-06-10): servo lag+slew TEMPORARILY DISABLED
-    // (#if 0) to isolate the cadence variable — restores the 035-era
-    // idealized instant servo on BOTH aileron (roll) and elevator (pitch),
-    // keeping the rest of the 20 Hz bundle. The t6 20 Hz+servo arm showed
-    // limited tracking (pctInStreak 1.6% at gen 267, basin risk); this arm
-    // answers "what does 20 Hz do WITHOUT the servo damping". The
-    // per-scenario servoTau/servoSlew draws still happen (PRNG order
-    // preserved); they are simply unused here. RE-ENABLE with #if 1.
-#if 0
+    if (Global::servoModelEnabled)
     {
       const SCALAR kFullThrowSurface = static_cast<SCALAR>(0.5);
+      const SCALAR kPwmFrameSec = static_cast<SCALAR>(0.020);  // 50 Hz command frame
       const SCALAR slewCap = kFullThrowSurface
           * static_cast<SCALAR>(Global::servoSlew) * static_cast<SCALAR>(dt);
-      const SCALAR servoTau = static_cast<SCALAR>(Global::servoTau);
-      // 037 fix: EXACT dt-invariant first-order lag blend (1 - exp(-dt/tau)),
-      // with the slew cap applied to the lag STEP rather than compounded with
-      // it. The prior code slew-clamped the error THEN multiplied by the blend,
-      // so slew and lag MULTIPLIED -- making the effective servo rate ~4x too
-      // slow. Now tau alone sets the response for small inputs; the slew cap
-      // only clips large/fast commands. Both terms are dt-scaled (FDM substep
-      // dt), so the servo is cadence-invariant (identical at any control rate).
-      const SCALAR lagBlend = (servoTau > static_cast<SCALAR>(0.0))
-          ? (static_cast<SCALAR>(1.0)
-             - exp(-static_cast<SCALAR>(dt) / servoTau))
-          : static_cast<SCALAR>(1.0);
 
-      // Aileron channel: lag toward target, then slew-cap the step.
+      // PWM latch: timer was initialized to (frame - phase) at scenario
+      // reset, so the FIRST latch lands `phase` seconds in; thereafter every
+      // 20 ms. Until the first latch the servo holds neutral (the reset
+      // state) — commands are coast-zero during the engage window anyway.
+      servoPwmTimerSec += static_cast<SCALAR>(dt);
+      while (servoPwmTimerSec >= kPwmFrameSec) {
+        servoLatchedAileron  = myInputs.aileron;
+        servoLatchedElevator = myInputs.elevator;
+        servoPwmTimerSec -= kPwmFrameSec;
+      }
+
+      // Aileron channel: slew toward the LATCHED target.
       {
-        SCALAR step = (myInputs.aileron - servoStateAileron) * lagBlend;
+        SCALAR step = servoLatchedAileron - servoStateAileron;
         if (step >  slewCap) step =  slewCap;
         if (step < -slewCap) step = -slewCap;
         servoStateAileron += step;
         myInputs.aileron = servoStateAileron;
       }
-      // Elevator channel: lag toward target, then slew-cap the step.
+      // Elevator channel: slew toward the LATCHED target.
       {
-        SCALAR step = (myInputs.elevator - servoStateElevator) * lagBlend;
+        SCALAR step = servoLatchedElevator - servoStateElevator;
         if (step >  slewCap) step =  slewCap;
         if (step < -slewCap) step = -slewCap;
         servoStateElevator += step;
         myInputs.elevator = servoStateElevator;
       }
     }
-#endif  // 037 t7 servo A/B disable
 
     aero(&myInputs, m_V_local_airmass_grad, v_R_omega_gust_body, v_F_aero, v_M_aero);
 

--- a/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
+++ b/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
@@ -250,6 +250,16 @@ void CRRC_AirplaneSim_Larcsim::update(TSimInputs* inputs,
     // (full throw magnitude = 0.5). servoSlew is in full-throw/s where
     // full-throw = 1.0 (the [-1,1] crrcsim convention), so the per-substep
     // surface-unit slew cap is 0.5 * servoSlew * dt.
+    //
+    // 037 t7 A/B (operator 2026-06-10): servo lag+slew TEMPORARILY DISABLED
+    // (#if 0) to isolate the cadence variable — restores the 035-era
+    // idealized instant servo on BOTH aileron (roll) and elevator (pitch),
+    // keeping the rest of the 20 Hz bundle. The t6 20 Hz+servo arm showed
+    // limited tracking (pctInStreak 1.6% at gen 267, basin risk); this arm
+    // answers "what does 20 Hz do WITHOUT the servo damping". The
+    // per-scenario servoTau/servoSlew draws still happen (PRNG order
+    // preserved); they are simply unused here. RE-ENABLE with #if 1.
+#if 0
     {
       const SCALAR kFullThrowSurface = static_cast<SCALAR>(0.5);
       const SCALAR slewCap = kFullThrowSurface
@@ -284,6 +294,7 @@ void CRRC_AirplaneSim_Larcsim::update(TSimInputs* inputs,
         myInputs.elevator = servoStateElevator;
       }
     }
+#endif  // 037 t7 servo A/B disable
 
     aero(&myInputs, m_V_local_airmass_grad, v_R_omega_gust_body, v_F_aero, v_M_aero);
 

--- a/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
+++ b/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
@@ -28,6 +28,7 @@
 #include "fdm_larcsim.h"
 
 #include <math.h>
+#include <algorithm>        // 037 std::min for the in-FDM actuator lag blend
 #include "../../global.h"   // 034 US4 — Global::craft* per-scenario carriers
 #include <iostream>
 
@@ -111,6 +112,16 @@ void CRRC_AirplaneSim_Larcsim::initAirplaneState(double dRelVel,
   Cm_de   = nominal_Cm_de   * (static_cast<SCALAR>(1.0) + static_cast<SCALAR>(Global::craftPitchEffDelta));
   CL_de   = nominal_CL_de   * (static_cast<SCALAR>(1.0) + static_cast<SCALAR>(Global::craftPitchEffDelta));
   Cl_da   = nominal_Cl_da   * (static_cast<SCALAR>(1.0) + static_cast<SCALAR>(Global::craftRollEffDelta));
+
+  // 037 actuator dynamics (operator decision: in-FDM, substep dt). Reset the
+  // persistent actuator-filter state at scenario reset so a fresh scenario
+  // starts from neutral surfaces and full commanded thrust, not the previous
+  // flight's lagged state. Servo surfaces start neutral (0.0); the thrust
+  // lag state starts at 1.0 (full applied scale) so the very first lag step
+  // is a no-op until power->step produces a commanded thrust.
+  servoStateAileron  = static_cast<SCALAR>(0.0);
+  servoStateElevator = static_cast<SCALAR>(0.0);
+  thrustStateScale   = static_cast<SCALAR>(1.0);
 
   Phi       = dPhi;         // bank/roll angle  [rad]
   Theta     = dTheta;       // pitch attitude angle [rad]
@@ -223,6 +234,54 @@ void CRRC_AirplaneSim_Larcsim::update(TSimInputs* inputs,
     ls_aux(v_V_local_airmass, v_V_gust_body);
 
     env->ControllerCallback(dt, this, inputs, &myInputs);
+
+    // 037 actuator dynamics (operator decision: in-FDM, substep dt). Apply a
+    // per-channel servo model (slew-rate limit + first-order lag) to the
+    // aileron/elevator surface commands BEFORE they feed the aero force/moment
+    // calc and the engine call. This is a FDM physics filter on the command
+    // surface -- NOT a command-path filter in the controller. dt here is the
+    // LaRCSim per-substep integration step (the same dt passed to ls_step and
+    // engine), not the outer frame interval. Pure deterministic arithmetic on
+    // dt -- no PRNG. With the nominal centers (servoTau 0.020 s, servoSlew 6.0
+    // full-throw/s) this is a small but non-zero lag, so a no-variation run
+    // differs from pre-037 ONLY by this intended nominal lag model.
+    //
+    // Surface convention: TSimInputs aileron/elevator are in [-0.5, 0.5]
+    // (full throw magnitude = 0.5). servoSlew is in full-throw/s where
+    // full-throw = 1.0 (the [-1,1] crrcsim convention), so the per-substep
+    // surface-unit slew cap is 0.5 * servoSlew * dt.
+    {
+      const SCALAR kFullThrowSurface = static_cast<SCALAR>(0.5);
+      const SCALAR slewCap = kFullThrowSurface
+          * static_cast<SCALAR>(Global::servoSlew) * static_cast<SCALAR>(dt);
+      const SCALAR servoTau = static_cast<SCALAR>(Global::servoTau);
+      // First-order lag blend; min(1,...) keeps it stable if dt >= tau.
+      const SCALAR lagBlend = (servoTau > static_cast<SCALAR>(0.0))
+          ? std::min(static_cast<SCALAR>(1.0),
+                     static_cast<SCALAR>(dt) / servoTau)
+          : static_cast<SCALAR>(1.0);
+
+      // Aileron channel.
+      {
+        SCALAR target = myInputs.aileron;
+        SCALAR delta = target - servoStateAileron;
+        if (delta >  slewCap) delta =  slewCap;
+        if (delta < -slewCap) delta = -slewCap;
+        SCALAR slewed = servoStateAileron + delta;
+        servoStateAileron += (slewed - servoStateAileron) * lagBlend;
+        myInputs.aileron = servoStateAileron;
+      }
+      // Elevator channel.
+      {
+        SCALAR target = myInputs.elevator;
+        SCALAR delta = target - servoStateElevator;
+        if (delta >  slewCap) delta =  slewCap;
+        if (delta < -slewCap) delta = -slewCap;
+        SCALAR slewed = servoStateElevator + delta;
+        servoStateElevator += (slewed - servoStateElevator) * lagBlend;
+        myInputs.elevator = servoStateElevator;
+      }
+    }
 
     aero(&myInputs, m_V_local_airmass_grad, v_R_omega_gust_body, v_F_aero, v_M_aero);
 
@@ -375,6 +434,14 @@ void CRRC_AirplaneSim_Larcsim::LoadFromXML(SimpleXMLTransfer* xml, int nVerbosit
   nominal_CG_arm  = CG_arm;
   nominal_Cl_da   = Cl_da;
 
+  // 037 actuator dynamics (operator decision: in-FDM, substep dt). Initialize
+  // the persistent actuator-filter state at LOAD so any pre-scenario trim call
+  // (trimAirplaneState -> engine(0,...)) sees defined state; it is RE-reset to
+  // these same values at every initAirplaneState (scenario reset).
+  servoStateAileron  = static_cast<SCALAR>(0.0);
+  servoStateElevator = static_cast<SCALAR>(0.0);
+  thrustStateScale   = static_cast<SCALAR>(1.0);
+
   flap_drag      = aero->getDouble("flap.drag", 0);
   flap_lift      = aero->getDouble("flap.lift", 0);
   flap_moment    = aero->getDouble("flap.moment", 0);
@@ -521,13 +588,32 @@ void CRRC_AirplaneSim_Larcsim::engine( SCALAR dt, TSimInputs* inputs, CRRCMath::
   inputs->pitch = 1;
   power->step(dt, inputs, v_V_wind_body*FT_TO_M, &v_F, &v_M);
 
-  // 034 US4 — scale propeller thrust by per-scenario craft factor (default
-  // 1.0 ⇒ no-op). Counter-torque scales together with thrust since it
+  // 037 actuator dynamics (operator decision: in-FDM, substep dt). First-order
+  // lag on the APPLIED thrust scale toward the commanded craftThrustScale.
+  // Models motor/ESC spool-up: the commanded thrust scale (craftThrustScale)
+  // is the steady-state target; thrustStateScale relaxes toward it at
+  // dt/thrustTau each substep. dt is the LaRCSim per-substep step (passed in
+  // by update()). Pure deterministic arithmetic on dt; with the nominal
+  // thrustTau (0.150 s) this is a non-zero lag, the intended physics change.
+  // State persists across substeps; reset to 1.0 at initAirplaneState.
+  {
+    const SCALAR commandedScale = static_cast<SCALAR>(Global::craftThrustScale);
+    const SCALAR thrustTau = static_cast<SCALAR>(Global::thrustTau);
+    const SCALAR lagBlend = (thrustTau > static_cast<SCALAR>(0.0))
+        ? std::min(static_cast<SCALAR>(1.0), dt / thrustTau)
+        : static_cast<SCALAR>(1.0);
+    thrustStateScale += (commandedScale - thrustStateScale) * lagBlend;
+  }
+
+  // 034 US4 -- scale propeller thrust by per-scenario craft factor (default
+  // 1.0 = no-op), now routed through the 037 lagged thrust state so the
+  // applied scale spools toward the commanded craftThrustScale instead of
+  // stepping instantly. Counter-torque scales together with thrust since it
   // physically tracks shaft power, which tracks force at constant prop
   // geometry. Carrier (Global::craftThrustScale) is set per-scenario by
   // inputdev_autoc after autoc-side applyVariationScale ramping.
-  v_F *= Global::craftThrustScale;
-  v_M *= Global::craftThrustScale;
+  v_F *= thrustStateScale;
+  v_M *= thrustStateScale;
 
   // Convert SI to that other buggy system.
   v_F *= N_TO_LBF;

--- a/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
+++ b/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
@@ -270,15 +270,20 @@ void CRRC_AirplaneSim_Larcsim::update(TSimInputs* inputs,
     // Deterministic: pure dt arithmetic + per-scenario state reset in
     // initAirplaneState; no PRNG here.
     //
-    // Surface convention: TSimInputs aileron/elevator are in [-0.5, 0.5]
-    // (full throw magnitude = 0.5). servoSlew is in full-throw/s where
-    // full-throw = 1.0 (the [-1,1] crrcsim convention), so the per-substep
-    // surface-unit slew cap is 0.5 * servoSlew * dt.
+    // UNITS (operator 2026-06-12, post-t8 audit): Global::servoSlew is in
+    // AUTOC command units/s — the [-1, +1] NN/INAV span, full range = 2.0
+    // units = the full mechanical span (DSM-44 90°). TSimInputs surfaces are
+    // [-0.5, +0.5] = command/2, so the platform translation to a per-substep
+    // surface-unit slew cap is 0.5 * servoSlew * dt. (The 2×-slow t6/t8 bug
+    // was NOT this factor — it was the autoc-side center being derived in
+    // spans/s, half the autoc-unit number; fixed in craft_variation.h,
+    // center ≈24.2 units/s = 82.5 ms full-span transit. See finding.md
+    // §t8-final.)
     if (Global::servoModelEnabled)
     {
-      const SCALAR kFullThrowSurface = static_cast<SCALAR>(0.5);
+      const SCALAR kCommandToSurface = static_cast<SCALAR>(0.5);  // autoc [-1,1] -> surface [-0.5,0.5]
       const SCALAR kPwmFrameSec = static_cast<SCALAR>(0.020);  // 50 Hz command frame
-      const SCALAR slewCap = kFullThrowSurface
+      const SCALAR slewCap = kCommandToSurface
           * static_cast<SCALAR>(Global::servoSlew) * static_cast<SCALAR>(dt);
 
       // PWM latch: timer was initialized to (frame - phase) at scenario

--- a/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
+++ b/src/mod_fdm/fdm_larcsim/fdm_larcsim.cpp
@@ -255,30 +255,32 @@ void CRRC_AirplaneSim_Larcsim::update(TSimInputs* inputs,
       const SCALAR slewCap = kFullThrowSurface
           * static_cast<SCALAR>(Global::servoSlew) * static_cast<SCALAR>(dt);
       const SCALAR servoTau = static_cast<SCALAR>(Global::servoTau);
-      // First-order lag blend; min(1,...) keeps it stable if dt >= tau.
+      // 037 fix: EXACT dt-invariant first-order lag blend (1 - exp(-dt/tau)),
+      // with the slew cap applied to the lag STEP rather than compounded with
+      // it. The prior code slew-clamped the error THEN multiplied by the blend,
+      // so slew and lag MULTIPLIED -- making the effective servo rate ~4x too
+      // slow. Now tau alone sets the response for small inputs; the slew cap
+      // only clips large/fast commands. Both terms are dt-scaled (FDM substep
+      // dt), so the servo is cadence-invariant (identical at any control rate).
       const SCALAR lagBlend = (servoTau > static_cast<SCALAR>(0.0))
-          ? std::min(static_cast<SCALAR>(1.0),
-                     static_cast<SCALAR>(dt) / servoTau)
+          ? (static_cast<SCALAR>(1.0)
+             - exp(-static_cast<SCALAR>(dt) / servoTau))
           : static_cast<SCALAR>(1.0);
 
-      // Aileron channel.
+      // Aileron channel: lag toward target, then slew-cap the step.
       {
-        SCALAR target = myInputs.aileron;
-        SCALAR delta = target - servoStateAileron;
-        if (delta >  slewCap) delta =  slewCap;
-        if (delta < -slewCap) delta = -slewCap;
-        SCALAR slewed = servoStateAileron + delta;
-        servoStateAileron += (slewed - servoStateAileron) * lagBlend;
+        SCALAR step = (myInputs.aileron - servoStateAileron) * lagBlend;
+        if (step >  slewCap) step =  slewCap;
+        if (step < -slewCap) step = -slewCap;
+        servoStateAileron += step;
         myInputs.aileron = servoStateAileron;
       }
-      // Elevator channel.
+      // Elevator channel: lag toward target, then slew-cap the step.
       {
-        SCALAR target = myInputs.elevator;
-        SCALAR delta = target - servoStateElevator;
-        if (delta >  slewCap) delta =  slewCap;
-        if (delta < -slewCap) delta = -slewCap;
-        SCALAR slewed = servoStateElevator + delta;
-        servoStateElevator += (slewed - servoStateElevator) * lagBlend;
+        SCALAR step = (myInputs.elevator - servoStateElevator) * lagBlend;
+        if (step >  slewCap) step =  slewCap;
+        if (step < -slewCap) step = -slewCap;
+        servoStateElevator += step;
         myInputs.elevator = servoStateElevator;
       }
     }

--- a/src/mod_fdm/fdm_larcsim/fdm_larcsim.h
+++ b/src/mod_fdm/fdm_larcsim/fdm_larcsim.h
@@ -208,16 +208,19 @@ class CRRC_AirplaneSim_Larcsim : public EOM01
    SCALAR nominal_Cl_da;
 
    // 037 actuator dynamics (operator decision: in-FDM, substep dt).
-   // Persistent per-substep actuator-filter state. The servo channels run a
-   // slew-rate limiter followed by a first-order lag toward the slewed target;
-   // the thrust channel runs a first-order lag on the applied thrust scale.
-   // State carries across substeps within a scenario and is RESET to the
-   // commanded/identity value at initAirplaneState (scenario reset) so a fresh
-   // scenario does not inherit the previous flight's lagged surfaces.
-   // Surface state is in TSimInputs surface units ([-0.5, 0.5] full throw).
-   SCALAR servoStateAileron;   ///< lagged aileron surface (TSimInputs units)
-   SCALAR servoStateElevator;  ///< lagged elevator surface (TSimInputs units)
-   SCALAR thrustStateScale;    ///< lagged thrust scale (1.0 = full commanded)
+   // Persistent per-substep actuator-filter state, RESET at initAirplaneState
+   // (scenario reset) so a fresh scenario does not inherit the previous
+   // flight's state. Surface state is in TSimInputs units ([-0.5, 0.5]).
+   //
+   // 037 servo v2: the servo is a 50 Hz PWM command LATCH (per-scenario
+   // phase = the 0-20 ms dead-time) + pure slew toward the latched target
+   // (no first-order lag). Gated on Global::servoModelEnabled.
+   SCALAR servoStateAileron;     ///< actual aileron surface (slews toward latch)
+   SCALAR servoStateElevator;    ///< actual elevator surface (slews toward latch)
+   SCALAR servoLatchedAileron;   ///< aileron command latched at the last PWM frame
+   SCALAR servoLatchedElevator;  ///< elevator command latched at the last PWM frame
+   SCALAR servoPwmTimerSec;      ///< accumulates substep dt; latch fires at >= 20 ms
+   SCALAR thrustStateScale;      ///< lagged thrust scale (1.0 = full commanded)
 
    SCALAR span_eff;  // span efficiency: Effective span  0.95 for most planes, 0.85 flying wing
    SCALAR CL_CD0;    // CL at minimum profile CD: 0.30 for 7037, 0.15 MH32, 0.0 RG15, AGxx, power

--- a/src/mod_fdm/fdm_larcsim/fdm_larcsim.h
+++ b/src/mod_fdm/fdm_larcsim/fdm_larcsim.h
@@ -206,7 +206,19 @@ class CRRC_AirplaneSim_Larcsim : public EOM01
    SCALAR nominal_CD_prof;
    SCALAR nominal_CG_arm;
    SCALAR nominal_Cl_da;
-   
+
+   // 037 actuator dynamics (operator decision: in-FDM, substep dt).
+   // Persistent per-substep actuator-filter state. The servo channels run a
+   // slew-rate limiter followed by a first-order lag toward the slewed target;
+   // the thrust channel runs a first-order lag on the applied thrust scale.
+   // State carries across substeps within a scenario and is RESET to the
+   // commanded/identity value at initAirplaneState (scenario reset) so a fresh
+   // scenario does not inherit the previous flight's lagged surfaces.
+   // Surface state is in TSimInputs surface units ([-0.5, 0.5] full throw).
+   SCALAR servoStateAileron;   ///< lagged aileron surface (TSimInputs units)
+   SCALAR servoStateElevator;  ///< lagged elevator surface (TSimInputs units)
+   SCALAR thrustStateScale;    ///< lagged thrust scale (1.0 = full commanded)
+
    SCALAR span_eff;  // span efficiency: Effective span  0.95 for most planes, 0.85 flying wing
    SCALAR CL_CD0;    // CL at minimum profile CD: 0.30 for 7037, 0.15 MH32, 0.0 RG15, AGxx, power
    SCALAR CD_CLsq;   // d(CD)/d(CL^2),  curvature of parabolic profile polar: 0.01 composites, 0.015 saggy ships, 0.02 beat up ship

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -13,6 +13,9 @@
 #include "crrcsim_tracker_helper.h"
 
 #include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
 
 #include "autoc/eval/arena.h"
 #include "autoc/eval/derived_features.h"  // 032 phase 1 — compute_pair_span
@@ -58,12 +61,31 @@ void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
     // Reset NN recurrent state at scenario start (no-op for feedforward).
     nn.reset();
 
-    // Pre-fill history with source[0] projection replicated 6×, so the NN
+    // 037 T022 — fail loud on a source library whose tick spacing does not
+    // match the compiled cadence (the caller advances one SIM_TIME_STEP_MSEC
+    // of chase physics per source tick; a 100 ms-recorded library at a 50 ms
+    // cadence would silently play the target at 2× speed). Mirrors
+    // src/eval/tracker_stepper.cc::initScenario.
+    if (source_->samples.size() >= 2) {
+        const double gapMsec =
+            source_->samples[1].simTimeMsec - source_->samples[0].simTimeMsec;
+        if (std::lround(gapMsec) != SIM_TIME_STEP_MSEC) {
+            throw std::runtime_error(
+                "CrrcsimTrackerHelper: source trajectory tick spacing " +
+                std::to_string(gapMsec) + " ms != compiled SIM_TIME_STEP_MSEC " +
+                std::to_string(SIM_TIME_STEP_MSEC) +
+                " ms — rebake the M2 source library at the current cadence.");
+        }
+    }
+
+    // Pre-fill history with source[0] projection replicated across the WHOLE
+    // observation ring (037: depth grew with the R5 lag window), so the NN
     // sees a coherent stationary-source history at first tick. Mirrors the
-    // M9.preB minisim TrackerStepper init for the pre_roll == 0 case.
+    // minisim TrackerStepper init for the pre_roll == 0 case.
+    obs_ring_.reset();
     if (!source_->samples.empty()) {
         const SourceTickSample& first = source_->samples.front();
-        for (int i = 0; i < 6; ++i) {
+        for (int i = 0; i < TrackerObservationRing::kDepth; ++i) {
             projectAndShiftHistory(first, chaseState, init);
         }
     }
@@ -74,16 +96,9 @@ void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
 void CrrcsimTrackerHelper::projectAndShiftHistory(const SourceTickSample& target,
                                                   const AircraftState& chaseState,
                                                   const WorkerInit& init) {
-    // Shift slots [1..5] → [0..4]; new "now" lands at index 5.
-    for (int i = 0; i < 5; ++i) {
-        history_.left_x[i] = history_.left_x[i + 1];      // raw-ok: NN-byte-format primitive
-        history_.left_y[i] = history_.left_y[i + 1];      // raw-ok: NN-byte-format primitive
-        history_.left_cep[i] = history_.left_cep[i + 1];  // raw-ok: NN-byte-format primitive
-        history_.right_x[i] = history_.right_x[i + 1];    // raw-ok: NN-byte-format primitive
-        history_.right_y[i] = history_.right_y[i + 1];    // raw-ok: NN-byte-format primitive
-        history_.right_cep[i] = history_.right_cep[i + 1];// raw-ok: NN-byte-format primitive
-        history_.span[i] = history_.span[i + 1];          // raw-ok: NN-byte-format primitive — 032 phase 1
-    }
+    // 037 T022 — observations land in the deep ring; the 6-slot gather view
+    // (history_) is materialized at the R5 lag offsets at the end of this
+    // function. (Pre-037: 6-slot shift-left register.)
 
     // 030 V1 priming — cameras + beacons + airframe come from WorkerInit
     // (sent once per worker; autoc-side parses autoc-tracker.ini at startup).
@@ -109,12 +124,13 @@ void CrrcsimTrackerHelper::projectAndShiftHistory(const SourceTickSample& target
     proj.beacon = init.beaconRightConfig;
     BeaconObservation right = projectBeacon(proj);
 
-    history_.left_x[5] = left.screen_x;       // raw-ok: NN-byte-format primitive
-    history_.left_y[5] = left.screen_y;       // raw-ok: NN-byte-format primitive
-    history_.left_cep[5] = left.cep;          // raw-ok: NN-byte-format primitive
-    history_.right_x[5] = right.screen_x;     // raw-ok: NN-byte-format primitive
-    history_.right_y[5] = right.screen_y;     // raw-ok: NN-byte-format primitive
-    history_.right_cep[5] = right.cep;        // raw-ok: NN-byte-format primitive
+    TrackerObservationRing::Record rec;
+    rec.left_x = left.screen_x;       // raw-ok: NN-byte-format primitive
+    rec.left_y = left.screen_y;       // raw-ok: NN-byte-format primitive
+    rec.left_cep = left.cep;          // raw-ok: NN-byte-format primitive
+    rec.right_x = right.screen_x;     // raw-ok: NN-byte-format primitive
+    rec.right_y = right.screen_y;     // raw-ok: NN-byte-format primitive
+    rec.right_cep = right.cep;        // raw-ok: NN-byte-format primitive
 
     // 032 PHASE 1 — Cache beacon-pair span at the current tick. CEP-gated:
     // if EITHER beacon's CEP exceeds the configured threshold, substitute
@@ -126,15 +142,17 @@ void CrrcsimTrackerHelper::projectAndShiftHistory(const SourceTickSample& target
         left.cep >= cep_gate_threshold ||
         right.cep >= cep_gate_threshold;
     if (cep_gated) {
-        history_.span[5] = 0.0f;
+        rec.span = 0.0f;
     } else {
-        history_.span[5] = static_cast<float>(  // raw-ok: NN-byte-format slot write
+        rec.span = static_cast<float>(  // raw-ok: NN-byte-format slot write
             autoc::eval::compute_pair_span(
                 static_cast<gp_scalar>(left.screen_x),
                 static_cast<gp_scalar>(left.screen_y),
                 static_cast<gp_scalar>(right.screen_x),
                 static_cast<gp_scalar>(right.screen_y)));
     }
+    obs_ring_.push(rec);
+    obs_ring_.materialize(history_);
 
     // M2 dmp recording — mirror minisim's M8b populate.
     last_camera_view_.camera_pose_world_pos =

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -66,13 +66,22 @@ void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
     // of chase physics per source tick; a 100 ms-recorded library at a 50 ms
     // cadence would silently play the target at 2× speed). Mirrors
     // src/eval/tracker_stepper.cc::initScenario.
+    // 2026-06-15: check the AVERAGE gap, not the first gap. simTimeMsec is the
+    // 200 Hz/5 ms step clock TRUNCATED to integer ms, so a clean 20 Hz/50 ms
+    // source records gaps of 49/50/51 (re-syncing to exact 50-multiples) with
+    // the FIRST gap deterministically 49 — a single-gap test spuriously rejects
+    // every valid source. (last-first)/(N-1) recovers the true cadence exactly
+    // (50.0) and still catches a real mismatch (a 100 ms 10 Hz source → 100).
+    // Proper fix = round/step-count the simTimeMsec stamp (BACKLOG).
     if (source_->samples.size() >= 2) {
-        const double gapMsec =
-            source_->samples[1].simTimeMsec - source_->samples[0].simTimeMsec;
-        if (std::lround(gapMsec) != SIM_TIME_STEP_MSEC) {
+        const auto& s = source_->samples;
+        const double avgGapMsec =
+            (s.back().simTimeMsec - s.front().simTimeMsec) /
+            static_cast<double>(s.size() - 1);
+        if (std::lround(avgGapMsec) != SIM_TIME_STEP_MSEC) {
             throw std::runtime_error(
-                "CrrcsimTrackerHelper: source trajectory tick spacing " +
-                std::to_string(gapMsec) + " ms != compiled SIM_TIME_STEP_MSEC " +
+                "CrrcsimTrackerHelper: source trajectory avg tick spacing " +
+                std::to_string(avgGapMsec) + " ms != compiled SIM_TIME_STEP_MSEC " +
                 std::to_string(SIM_TIME_STEP_MSEC) +
                 " ms — rebake the M2 source library at the current cadence.");
         }

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
@@ -93,6 +93,10 @@ private:
                                 const WorkerInit& init);
 
     size_t cursor_ = 0;
+    // 037 T022 — deep per-tick observation ring; history_ stays the 6-slot
+    // gather VIEW materialized from the ring at the R5 ms-based lag offsets
+    // (mirrors src/eval/tracker_stepper.cc — keep both bodies in lockstep).
+    TrackerObservationRing obs_ring_{};
     TrackerHistoryWindow history_{};
     autoc::eval::CrashHull crash_hull_{};
     uint32_t prng_state_ = 0;

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -321,6 +321,12 @@ int T_TX_InterfaceAUTOC::init(SimpleXMLTransfer *config)
   }
   gEvalUpdateIntervalMsec = init_.controlIntervalMsec;
 
+  // 037 servo v2 -- take the in-FDM servo-model switch from the primed
+  // WorkerInit (ServoModelEnabled ini knob on the parent).
+  Global::servoModelEnabled = init_.servoModelEnabled;
+  std::cerr << "[AUTOC] servoModelEnabled="
+            << (Global::servoModelEnabled ? "true" : "false") << std::endl;
+
   // Compute frame-counter cadence triple and enforce integrality at startup.
   // Constraint: outer cycleLength_ms must divide gEvalUpdateIntervalMsec
   // exactly. CTime already rounds cycleLength to a multiple of
@@ -574,6 +580,10 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       Global::servoTau           = static_cast<double>(activeScenario.craftServoTau);
       Global::servoSlew          = static_cast<double>(activeScenario.craftServoSlew);
       Global::thrustTau          = static_cast<double>(activeScenario.craftThrustTau);
+      // 037 servo v2 -- per-scenario PWM latch phase (the 0-20 ms command
+      // dead-time); consumed by the fdm_larcsim latch when
+      // Global::servoModelEnabled.
+      Global::servoPwmPhase      = static_cast<double>(activeScenario.craftServoPwmPhase);
 
 #ifdef DETAILED_LOGGING
       std::cerr << "VARIATIONS1: heading=" << (Global::entryHeadingOffset * 180.0/M_PI)

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -576,8 +576,8 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       // 037 actuator dynamics (operator decision: in-FDM, substep dt).
       // Absolute physical actuator-filter params (already ramp-scaled toward
       // their nominal centers per-eval by applyVariationScale). Consumed in
-      // the fdm_larcsim per-substep update (servo lag+slew, thrust lag).
-      Global::servoTau           = static_cast<double>(activeScenario.craftServoTau);
+      // the fdm_larcsim per-substep update (servo slew, thrust lag).
+      // (servo first-order tau removed 2026-06-12 — v2 has no lag term.)
       Global::servoSlew          = static_cast<double>(activeScenario.craftServoSlew);
       Global::thrustTau          = static_cast<double>(activeScenario.craftThrustTau);
       // 037 servo v2 -- per-scenario PWM latch phase (the 0-20 ms command

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -378,6 +378,24 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
   diagIndex = (diagIndex + 1) % DIAG_BUFFER_SIZE;
   if (diagCount < DIAG_BUFFER_SIZE) diagCount++;
 
+  // Apply pending commands when latency expires (no slew rate limiting —
+  // matches hardware path where Xiao writes NN outputs directly to
+  // MSP_SET_RAW_RC). 037 T017 FIX: this apply MUST run BEFORE the eval
+  // staging below. It used to sit at the end of this function, which worked
+  // at framesPerEval=2 (the eval frame staged, the in-between frame
+  // applied) but silently broke at framesPerEval=1 (20 Hz): every frame
+  // re-staged gPendingCommand — pushing readyTimeMsec forward — before the
+  // apply check could fire, so NN commands NEVER reached the surfaces and
+  // every genome flew the same ballistic coast (caught by the t4 basic-m1
+  // smoke run: 3000 identical fitnesses). Applying at frame top is
+  // behavior-identical at 10 Hz (the apply still lands on the t+50 frame).
+  if (gPendingCommand.valid && simTimeMsec >= gPendingCommand.readyTimeMsec) {
+    pitchCommand    = gPendingCommand.pitch;
+    rollCommand     = gPendingCommand.roll;
+    throttleCommand = gPendingCommand.throttle;
+    gPendingCommand.valid = false;
+  }
+
   // Frame-counter cadence (both headless and video):
   //  - Outer frame is a fixed cycleLength_ms (CTime). framesPerEval was
   //    validated at init to divide gEvalUpdateIntervalMsec exactly, so every
@@ -1310,14 +1328,8 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
 #endif
   }
 
-  // Apply pending commands when latency expires (no slew rate limiting — matches
-  // hardware path where Xiao writes NN outputs directly to MSP_SET_RAW_RC).
-  if (gPendingCommand.valid && simTimeMsec >= gPendingCommand.readyTimeMsec) {
-    pitchCommand    = gPendingCommand.pitch;
-    rollCommand     = gPendingCommand.roll;
-    throttleCommand = gPendingCommand.throttle;
-    gPendingCommand.valid = false;
-  }
+  // (037: pending-command apply moved to the TOP of this function — see the
+  // framesPerEval=1 staging-overwrite fix comment there.)
 
   // NN outputs are direct surface commands (unity pass-through). 026's
   // external ACRO PID experiment went NO-GO — see

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -625,8 +625,9 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
           crrcsimRabbitSpeed = static_cast<gp_scalar>(
               getSpeedAtTime(rabbitSpeedProfile, 0.0));
         }
-        engageDelayTicksRemaining = static_cast<int>(
-            (engageDelayMsec + gEvalUpdateIntervalMsec - 1) / gEvalUpdateIntervalMsec);
+        // 037 T020 -- shared rate-independent ceil helper (aircraft_state.h);
+        // same arithmetic as the former inline expression (bitwise no-op).
+        engageDelayTicksRemaining = engageDelayTicks(engageDelayMsec, gEvalUpdateIntervalMsec);
         engageCoastThrottle = static_cast<gp_scalar>(
             CLAMP_DEF(2.0 * (activeScenario.entrySpeedFactor - 1.0), -1.0, 1.0));
       }

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -89,7 +89,9 @@ ScenarioMetadata makePerEvalMeta(const WorkerInit& init,
 } // namespace
 
 // Global intervals used by AUTOC input (declared in header)
-unsigned long gEvalUpdateIntervalMsec = EVAL_UPDATE_INTERVAL_MSEC_DEFAULT;   // sensor/NN cadence
+// 037 T001 -- 0 = unset; the real cadence is assigned in init() from the primed
+// WorkerInit.controlIntervalMsec (single source of truth). No silent default.
+unsigned long gEvalUpdateIntervalMsec = 0;   // sensor/NN cadence (set from WorkerInit)
 unsigned long gComputeLatencyMsec = COMPUTE_LATENCY_MSEC_DEFAULT;           // simulated NN compute latency (sensor→output)
 
 static bool gInDeterministicTest = false;
@@ -277,8 +279,11 @@ int T_TX_InterfaceAUTOC::init(SimpleXMLTransfer *config)
 #if DEBUG_TX_INTERFACE > 0
   printf("int T_TX_InterfaceAUTOC::init(SimpleXMLTransfer* config)\n");
 #endif
-  // Allow runtime override of NN eval cadence and compute latency (sim time).
-  gEvalUpdateIntervalMsec = parseIntervalFromEnv("AUTOC_EVAL_INTERVAL_MSEC", EVAL_UPDATE_INTERVAL_MSEC_DEFAULT);
+  // 037 T001 -- the NN/sensor cadence (gEvalUpdateIntervalMsec) is NO LONGER
+  // read from the AUTOC_EVAL_INTERVAL_MSEC env var. It is now the single
+  // source of truth ControlIntervalMsec, set by the autoc parent (which alone
+  // has a ConfigManager) and delivered via the WorkerInit priming RPC below.
+  // Compute latency keeps its env override until 037 T024 retargets it.
   gComputeLatencyMsec = parseIntervalFromEnv("AUTOC_COMPUTE_LATENCY_MSEC", COMPUTE_LATENCY_MSEC_DEFAULT);
 
   // Engage delay: coast time before NN outputs reach surfaces (models INAV handoff)
@@ -290,10 +295,37 @@ int T_TX_InterfaceAUTOC::init(SimpleXMLTransfer *config)
     std::cerr << "[AUTOC] EngageDelayMsec=" << engageDelayMsec << std::endl;
   }
 
+  T_TX_Interface::init(config);
+
+  socket_ = new TcpSocket();
+  socket_->connect("127.0.0.1", cfg->callback_port);
+
+  // 030 V1 priming (2026-05-08) — phone home is the TCP connect above;
+  // autoc's ThreadPool sends the once-per-worker WorkerInit immediately
+  // after its accept(). Cache locally for all subsequent eval ticks.
+  // Loud-fail if priming RPC fails — no fallback. Mirrors minisim's
+  // SimProcess ctor priming receive (tools/minisim.cc).
+  init_ = receiveRPC<WorkerInit>(*socket_);
+  std::cerr << "[AUTOC] crrcsim worker primed mode=" << modeToString(init_.mode)
+            << " sourceList=" << init_.sourceList.size() << " scenarios"
+            << std::endl;
+
+  // 037 T001 -- take the control cadence from the primed WorkerInit. The autoc
+  // parent already validated it (> 0 and == SIM_TIME_STEP_MSEC at .ini load).
+  // Fail loud on the 0 sentinel: a worker must never silently default a rate.
+  if (init_.controlIntervalMsec == 0) {
+    std::cerr << "[AUTOC] FATAL: WorkerInit.controlIntervalMsec == 0 -- parent "
+              << "did not set the cadence (ControlIntervalMsec). No silent "
+              << "fallback." << std::endl;
+    std::exit(1);
+  }
+  gEvalUpdateIntervalMsec = init_.controlIntervalMsec;
+
   // Compute frame-counter cadence triple and enforce integrality at startup.
   // Constraint: outer cycleLength_ms must divide gEvalUpdateIntervalMsec
   // exactly. CTime already rounds cycleLength to a multiple of
-  // (Global::dt * 1000). See spec 024 WI4.
+  // (Global::dt * 1000). See spec 024 WI4. (Runs after priming now that the
+  // cadence arrives via WorkerInit rather than the environment.)
   {
     isHeadless = (config->getInt("video.enabled", 1) == 0);
     SimpleXMLTransfer* video = config->getChild("video", true);
@@ -322,21 +354,6 @@ int T_TX_InterfaceAUTOC::init(SimpleXMLTransfer *config)
               << " headless=" << (isHeadless ? "true" : "false")
               << std::endl;
   }
-
-  T_TX_Interface::init(config);
-
-  socket_ = new TcpSocket();
-  socket_->connect("127.0.0.1", cfg->callback_port);
-
-  // 030 V1 priming (2026-05-08) — phone home is the TCP connect above;
-  // autoc's ThreadPool sends the once-per-worker WorkerInit immediately
-  // after its accept(). Cache locally for all subsequent eval ticks.
-  // Loud-fail if priming RPC fails — no fallback. Mirrors minisim's
-  // SimProcess ctor priming receive (tools/minisim.cc).
-  init_ = receiveRPC<WorkerInit>(*socket_);
-  std::cerr << "[AUTOC] crrcsim worker primed mode=" << modeToString(init_.mode)
-            << " sourceList=" << init_.sourceList.size() << " scenarios"
-            << std::endl;
   return (0);
 }
 
@@ -532,6 +549,13 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       Global::craftThrustScale   = static_cast<double>(activeScenario.craftThrustScale);
       Global::craftPitchEffDelta = static_cast<double>(activeScenario.craftPitchEffDelta);
       Global::craftRollEffDelta  = static_cast<double>(activeScenario.craftRollEffDelta);
+      // 037 actuator dynamics (operator decision: in-FDM, substep dt).
+      // Absolute physical actuator-filter params (already ramp-scaled toward
+      // their nominal centers per-eval by applyVariationScale). Consumed in
+      // the fdm_larcsim per-substep update (servo lag+slew, thrust lag).
+      Global::servoTau           = static_cast<double>(activeScenario.craftServoTau);
+      Global::servoSlew          = static_cast<double>(activeScenario.craftServoSlew);
+      Global::thrustTau          = static_cast<double>(activeScenario.craftThrustTau);
 
 #ifdef DETAILED_LOGGING
       std::cerr << "VARIATIONS1: heading=" << (Global::entryHeadingOffset * 180.0/M_PI)
@@ -1230,6 +1254,13 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       sample.pitchCommand = aircraftState.getPitchCommand();
       sample.rollCommand = aircraftState.getRollCommand();
       sample.throttleCommand = aircraftState.getThrottleCommand();
+      // 037 actuator dynamics: the *Sim columns below record the PRE-FDM
+      // surface COMMAND (the controller output mapped into surface units), NOT
+      // the lagged/slew-limited surface the aircraft actually flew. The servo
+      // lag+slew and thrust lag live inside the FDM (fdm_larcsim.cpp, per
+      // substep) and operate on a copy (myInputs); the actuated surface is a
+      // physics detail and is intentionally NOT surfaced here. Recording stays
+      // command-honest (NN output), unchanged from pre-037.
       sample.elevatorSim = static_cast<gp_scalar>(-pitchCommand / 2.0);
       sample.aileronSim = static_cast<gp_scalar>(rollCommand / 2.0);
       sample.throttleSim = static_cast<gp_scalar>(throttleCommand / 2.0 + 0.5);

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.h
@@ -50,7 +50,9 @@ using namespace std;
 // #define DETAILED_LOGGING 1
 
 #define FEET_TO_METERS 0.3048
-#define EVAL_UPDATE_INTERVAL_MSEC_DEFAULT 100   // Sensor+NN cadence (~10Hz)
+// 037 T001 -- no EVAL_UPDATE_INTERVAL_MSEC_DEFAULT: the NN/sensor cadence has no
+// default. It is the single-source ControlIntervalMsec, validated by the autoc
+// parent and delivered via WorkerInit priming (see inputdev_autoc.cpp init()).
 #define COMPUTE_LATENCY_MSEC_DEFAULT 30         // Bench-measured: consolidated MSP fetch(12)+eval(5)+send(12)=29ms
 #define ENGAGE_DELAY_MSEC_DEFAULT 750           // Measured INAV MANUAL→autoc handoff delay (2026-04-07 flight)
 


### PR DESCRIPTION
## 037 (crrcsim) — in-FDM actuator dynamics + servo model v2 for the 20 Hz cadence

Paired with **autoc#6** (037 — 20 Hz control loop). crrcsim-side changes:

- **Servo model v2**: 50 Hz PWM latch + datasheet slew (DSM-44), ini-gated; exact in-FDM lag +
  slew-cap-on-step composition. (Removed dead servoTau — v2 has no lag term.)
- **In-FDM actuator dynamics** + cadence from WorkerInit (rate-independent control interval).
- **Tracker mirror on the R5 history ring** + source-spacing fail-loud (uses average gap, not first).
- framesPerEval=1 pending-command starvation fix (apply pending command at frame top).

Enables the honest-servo 20 Hz controller that t10 (the best M1 in project history) trained on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
