### PR TITLE
038 accurate-m2: situational-awareness input mirror + exact sim-time stamp + wind recording

### DIFF
--- a/src/SimStateHandler.cpp
+++ b/src/SimStateHandler.cpp
@@ -31,6 +31,7 @@
  *
  *  \author J. Reucker
  */
+#include <cmath>       // 038 P0-D-1: std::llround for the exact simTimeMsec stamp
 #include "i18n.h"
 #include "global.h"
 #include "aircraft.h"
@@ -389,5 +390,14 @@ unsigned long int SimStateHandler::getGameTimeSinceReset()
  */
 unsigned long int SimStateHandler::getSimulationTimeSinceReset()
 {
-  return (unsigned long int)(sim_steps*Global::dt*1000);
+  // 038 P0-D-1: round, don't truncate. In real arithmetic sim_steps*dt*1000 is
+  // an exact multiple of the control cadence (10 physics steps × 5 ms = 50 ms),
+  // but the binary double for Global::dt (0.005) carries tiny error, so the old
+  // (unsigned long) truncation produced 49/50/51 ms jitter around the exact
+  // 50-multiples (documented in crrcsim_tracker_helper.cpp / tracker_stepper.cc).
+  // Rounding snaps to the exact stamp → a 20 Hz run records exact 50 ms gaps and
+  // the M2 source-spacing check reverts to strict single-gap. Deterministic:
+  // sim_steps is fixed-multiloop in headless mode, so this is a pure re-round of
+  // an already-deterministic counter.
+  return (unsigned long int)std::llround(sim_steps * Global::dt * 1000.0);
 }

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -205,8 +205,7 @@ CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
     // Step 1b (038 P0-D FR-P0H): advance situational-awareness state from the
     // freshly-projected "now" beacon observation. Visibility uses the sentinel
     // threshold. Single-sourced update rule mirrored in TrackerStepper::stepOnce.
-    sa_state_.update(history_.left_x[5], history_.left_y[5], history_.left_cep[5],
-                     history_.right_x[5], history_.right_y[5], history_.right_cep[5],
+    sa_state_.update(history_.left_cep[5], history_.right_cep[5],
                      autoc::eval::kCepSentinelThreshold);
 
     // Step 2: gather tracker NN inputs.

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -61,6 +61,11 @@ void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
     // Reset NN recurrent state at scenario start (no-op for feedforward).
     nn.reset();
 
+    // 038 P0-D FR-P0H (A) — reset situational-awareness state per scenario
+    // (FR-030 determinism). Advanced only on real ticks in tick(), NOT during
+    // the history pre-fill below. Mirrors src/eval/tracker_stepper.cc.
+    sa_state_.reset();
+
     // 037 T022 — fail loud on a source library whose tick spacing does not
     // match the compiled cadence (the caller advances one SIM_TIME_STEP_MSEC
     // of chase physics per source tick; a 100 ms-recorded library at a 50 ms
@@ -197,10 +202,17 @@ CrashReason CrrcsimTrackerHelper::tick(AircraftState& chaseState,
     // + last_target_sample_ for M2 dmp recording).
     projectAndShiftHistory(target, chaseState, init);
 
+    // Step 1b (038 P0-D FR-P0H): advance situational-awareness state from the
+    // freshly-projected "now" beacon observation. Visibility uses the sentinel
+    // threshold. Single-sourced update rule mirrored in TrackerStepper::stepOnce.
+    sa_state_.update(history_.left_x[5], history_.left_y[5], history_.left_cep[5],
+                     history_.right_x[5], history_.right_y[5], history_.right_cep[5],
+                     autoc::eval::kCepSentinelThreshold);
+
     // Step 2: gather tracker NN inputs.
     TrackerInputs inputs = {};
     gather_tracker_inputs(chaseState, history_, init.flightArena,
-                          static_cast<float>(init.cepGateThreshold), inputs);
+                          static_cast<float>(init.cepGateThreshold), sa_state_, inputs);
 
     // Step 3: NN forward pass → updates chaseState.pitch/roll/throttle commands
     // (which inputdev_autoc.cpp's pending-command stage picks up post-tick).

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.cpp
@@ -66,22 +66,19 @@ void CrrcsimTrackerHelper::initScenario(const SourceScenarioTrajectory& source,
     // of chase physics per source tick; a 100 ms-recorded library at a 50 ms
     // cadence would silently play the target at 2× speed). Mirrors
     // src/eval/tracker_stepper.cc::initScenario.
-    // 2026-06-15: check the AVERAGE gap, not the first gap. simTimeMsec is the
-    // 200 Hz/5 ms step clock TRUNCATED to integer ms, so a clean 20 Hz/50 ms
-    // source records gaps of 49/50/51 (re-syncing to exact 50-multiples) with
-    // the FIRST gap deterministically 49 — a single-gap test spuriously rejects
-    // every valid source. (last-first)/(N-1) recovers the true cadence exactly
-    // (50.0) and still catches a real mismatch (a 100 ms 10 Hz source → 100).
-    // Proper fix = round/step-count the simTimeMsec stamp (BACKLOG).
+    // 038 P0-D-1: STRICT single-gap check restored. simTimeMsec is now
+    // round()-stamped (SimStateHandler::getSimulationTimeSinceReset) → exact
+    // 50 ms gaps, so the first gap is a faithful cadence probe again. (The
+    // 2026-06-15 average-gap workaround tolerated the old truncation jitter of
+    // 49/50/51 ms; that jitter is fixed at the stamp now.)
     if (source_->samples.size() >= 2) {
         const auto& s = source_->samples;
-        const double avgGapMsec =
-            (s.back().simTimeMsec - s.front().simTimeMsec) /
-            static_cast<double>(s.size() - 1);
-        if (std::lround(avgGapMsec) != SIM_TIME_STEP_MSEC) {
+        const long firstGapMsec =
+            std::lround(s[1].simTimeMsec - s[0].simTimeMsec);
+        if (firstGapMsec != SIM_TIME_STEP_MSEC) {
             throw std::runtime_error(
-                "CrrcsimTrackerHelper: source trajectory avg tick spacing " +
-                std::to_string(avgGapMsec) + " ms != compiled SIM_TIME_STEP_MSEC " +
+                "CrrcsimTrackerHelper: source trajectory tick spacing " +
+                std::to_string(firstGapMsec) + " ms != compiled SIM_TIME_STEP_MSEC " +
                 std::to_string(SIM_TIME_STEP_MSEC) +
                 " ms — rebake the M2 source library at the current cadence.");
         }

--- a/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
+++ b/src/mod_inputdev/inputdev_autoc/crrcsim_tracker_helper.h
@@ -98,6 +98,9 @@ private:
     // (mirrors src/eval/tracker_stepper.cc — keep both bodies in lockstep).
     TrackerObservationRing obs_ring_{};
     TrackerHistoryWindow history_{};
+    // 038 P0-D FR-P0H (A) — situational-awareness state; reset in initScenario,
+    // advanced each tick(). Shared update rule with minisim TrackerStepper.
+    SituationalAwarenessState sa_state_{};
     autoc::eval::CrashHull crash_hull_{};
     uint32_t prng_state_ = 0;
     int hull_fired_count_ = 0;

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -910,6 +910,23 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
     aircraftState.setPosition(p - pathOriginOffset);  // store virtual position
     // NN controller reads previous commands as feedback inputs — preserve them.
     aircraftState.setSimTimeMsec(simTimeMsec);
+    // 038 P0-D-3: record the steady wind (local airmass, NED, m/s) the FDM
+    // applied this tick, so realized gusty wind is auditable in the dmp
+    // (previously never set → zeros). getLastLocalAirmass() is NED ft/s;
+    // convert to m/s exactly like velocity_vector above. eom01 is non-null here
+    // (checked at the quaternion access above).
+    {
+      CRRCMath::Vector3 windLocalFtps = eom01->getLastLocalAirmass();  // NED, ft/s
+      gp_vec3 windNed{
+          static_cast<gp_scalar>(windLocalFtps(0) * FEET_TO_METERS),  // North
+          static_cast<gp_scalar>(windLocalFtps(1) * FEET_TO_METERS),  // East
+          static_cast<gp_scalar>(windLocalFtps(2) * FEET_TO_METERS)   // Down
+      };
+      if (isnan(windNed[0]) || isnan(windNed[1]) || isnan(windNed[2])) {
+        windNed = gp_vec3::Zero();
+      }
+      aircraftState.setWindVelocity(windNed);
+    }
     aircraftState.setRabbitOdometer(rabbitOdometer);
     aircraftState.setRabbitSpeed(crrcsimRabbitSpeed);
 

--- a/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
+++ b/src/mod_inputdev/inputdev_autoc/inputdev_autoc.cpp
@@ -516,7 +516,10 @@ void T_TX_InterfaceAUTOC::getInputData(TSimInputs *inputs)
       // Build/rebuild the NN controller for the new genome. Recurrent
       // hidden state (spec 027) lives inside the backend and is reset
       // per-span below.
-      nnController_ = std::make_unique<NNControllerBackend>(nnGenome);
+      // 038 P0-D FR-P0H (B): the backend carries the config FlightArena so the
+      // pathgen (M1) evaluate() path can populate the arena-awareness inputs.
+      // init_.flightArena is primed once per worker from the parent's ini.
+      nnController_ = std::make_unique<NNControllerBackend>(nnGenome, init_.flightArena);
 
       // Cache quat dot past reset
       quatDotPast[0] = quatDotPast[1] = quatDotPast[2] = quatDotPast[3] = 0.0;


### PR DESCRIPTION
crrcsim half of autoc 038-accurate-m2 (merge this BEFORE the autoc PR per submodule-first order).

- impl(038): P0-D-1 exact `simTimeMsec` stamp + P0-D-3 wind recording
- impl(038): FR-P0H situational-awareness input population (crrcsim mirror of the autoc gather functions)
- impl(038): US3 — `SituationalAwarenessState.update()` signature (exit_dir removed)
- merges: 031-beacon-camera (enhanced CEP) + merged 037 (origin/main) pulled into the 038 line

Autoc parent PR pins submodule pointer 5589989 (this branch head).

🤖 Generated with [Claude Code](https://claude.com/claude-code)